### PR TITLE
[codex] Add generated domain action forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,60 @@ selection.
 The older explicit `actions:` bulk-action API has been removed before 1.0. New
 bulk actions should be expressed in the domain action contract.
 
+### Action DSL Shape
+
+An action is host-owned metadata in the Selecto domain. The execution contract
+can use static values, or reference normalized form inputs with `{:input, id}`:
+
+```elixir
+defaction(:set_estimate, %{
+  id: :set_estimate,
+  label: "Set estimate",
+  type: :update,
+  scope: :row,
+  target: :work_item,
+  capability: "work_items.estimation",
+  inputs: %{
+    estimate_hours: %{type: :integer, label: "Estimate hours", required: true, min: 0}
+  },
+  confirmation: %{required: false, destructive: false},
+  execution: %{
+    kind: :updato,
+    operation: :update,
+    set: %{estimate_hours: {:input, :estimate_hours}}
+  },
+  links: %{
+    preview: "/api/v1/updato/work-items/actions/set_estimate/preview",
+    apply: "/api/v1/updato/work-items/actions/set_estimate/apply"
+  }
+})
+```
+
+The generated modal builds this request shape and sends it to the parent
+LiveView:
+
+```elixir
+%{
+  intent: "apply",
+  action_id: "set_estimate",
+  request: %{
+    "action" => "set_estimate",
+    "target" => %{"id" => 42},
+    "inputs" => %{"estimate_hours" => "8"},
+    "confirmed" => false
+  }
+}
+```
+
+The host should treat this as an intent, not as permission to write directly.
+Typical host responsibilities are:
+
+- Re-check target-aware action availability before showing the modal.
+- Preview/apply through a server-owned adapter.
+- Normalize and whitelist writable fields in that adapter.
+- Refresh the active Selecto query and close or reset the modal after apply.
+- Use flash/error messages for the result surface the host wants.
+
 ## Custom View Systems
 
 `selecto_components` supports external view packages through `SelectoComponents.Views.System`.

--- a/README.md
+++ b/README.md
@@ -214,10 +214,8 @@ from that contract are added to the bulk menu as generated action forms; opening
 one sends the same detail-modal event with `target.ids` set to the current
 selection.
 
-The older explicit `actions:` bulk-action API is deprecated before 1.0. New bulk
-actions should be expressed in the domain action contract; deprecated explicit
-actions are marked in rendered markup as `deprecated_explicit_bulk_action` and
-will be removed instead of carried as compatibility surface.
+The older explicit `actions:` bulk-action API has been removed before 1.0. New
+bulk actions should be expressed in the domain action contract.
 
 ## Custom View Systems
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,26 @@ forward "/selecto/orders/query-contract.json",
         domain: MyApp.SelectoDomains.Orders.domain()
 ```
 
+## Generated Domain Action Forms
+
+Domains can expose write-contract actions under `:actions`. Selecto Components
+projects those actions into the existing row-action modal path with generated
+ids like `domain_action_form_archive`. A detail view can select one of those ids
+as `row_click_action`; clicking a row opens `SelectoComponents.Modal.ActionFormModal`
+with the normalized action metadata, target row, inputs, confirmation state, and
+preview/apply request template.
+
+The modal does not execute writes directly. The host LiveView handles
+`{:selecto_action_form_submit, payload}` and calls its own preview/apply
+adapter, usually through `SelectoComponents.ActionFormHost.handle_submit/3`.
+After a successful apply, the host should refresh the active Selecto query so
+the row state reflects the write result.
+
+Bulk-scoped domain actions can be projected separately with
+`SelectoComponents.Actions.bulk_actions/2`. That helper returns the same
+live-component payload shape as generated row action forms, but defaults the
+target template to selected row ids.
+
 ## Custom View Systems
 
 `selecto_components` supports external view packages through `SelectoComponents.Views.System`.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,11 @@ from that contract are added to the bulk menu as generated action forms; opening
 one sends the same detail-modal event with `target.ids` set to the current
 selection.
 
+The older explicit `actions:` bulk-action API is deprecated before 1.0. New bulk
+actions should be expressed in the domain action contract; deprecated explicit
+actions are marked in rendered markup as `deprecated_explicit_bulk_action` and
+will be removed instead of carried as compatibility surface.
+
 ## Custom View Systems
 
 `selecto_components` supports external view packages through `SelectoComponents.Views.System`.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,12 @@ Bulk-scoped domain actions can be projected separately with
 live-component payload shape as generated row action forms, but defaults the
 target template to selected row ids.
 
+`SelectoComponents.EnhancedTable.BulkActions` can receive `:action_contract`,
+`:write_contract`, `:domain`, or `:selecto` assigns. Bulk-scoped domain actions
+from that contract are added to the bulk menu as generated action forms; opening
+one sends the same detail-modal event with `target.ids` set to the current
+selection.
+
 ## Custom View Systems
 
 `selecto_components` supports external view packages through `SelectoComponents.Views.System`.

--- a/lib/selecto_components/action_form_host.ex
+++ b/lib/selecto_components/action_form_host.ex
@@ -24,37 +24,18 @@ defmodule SelectoComponents.ActionFormHost do
   - `:after_apply` - callback invoked as `(socket, result)` before modal result assignment
   - `:format_error` - callback invoked as `(reason)` for host-specific error messages
   """
-  def handle_submit(socket, %{intent: "apply"} = payload, opts) do
-    action_id = Map.fetch!(payload, :action_id)
-    request = Map.fetch!(payload, :request)
-
-    opts
-    |> Keyword.fetch!(:apply)
-    |> call_action(action_id, request, socket)
-    |> case do
-      {:ok, result} ->
-        socket =
-          opts
-          |> Keyword.get(:after_apply, &default_after_apply/2)
-          |> call_after_apply(socket, result)
-
-        {:noreply, assign_result(socket, "apply", result)}
-
-      {:error, reason} ->
-        {:noreply, assign_error(socket, error_message(reason, opts))}
-    end
-  end
-
   def handle_submit(socket, payload, opts) when is_map(payload) do
     action_id = Map.fetch!(payload, :action_id)
     request = Map.fetch!(payload, :request)
+    intent = payload |> Map.get(:intent) |> normalize_intent()
 
     opts
-    |> Keyword.fetch!(:preview)
+    |> Keyword.fetch!(intent)
     |> call_action(action_id, request, socket)
     |> case do
       {:ok, result} ->
-        {:noreply, assign_result(socket, "preview", result)}
+        socket = maybe_after_apply(socket, intent, result, opts)
+        {:noreply, assign_result(socket, Atom.to_string(intent), result)}
 
       {:error, reason} ->
         {:noreply, assign_error(socket, error_message(reason, opts))}
@@ -104,6 +85,17 @@ defmodule SelectoComponents.ActionFormHost do
     do: callback.(socket, result)
 
   defp default_after_apply(socket, _result), do: socket
+
+  defp normalize_intent(intent) when intent in [:apply, "apply"], do: :apply
+  defp normalize_intent(_intent), do: :preview
+
+  defp maybe_after_apply(socket, :apply, result, opts) do
+    opts
+    |> Keyword.get(:after_apply, &default_after_apply/2)
+    |> call_after_apply(socket, result)
+  end
+
+  defp maybe_after_apply(socket, :preview, _result, _opts), do: socket
 
   defp error_message(reason, opts) do
     case Keyword.get(opts, :format_error) do

--- a/lib/selecto_components/action_form_host.ex
+++ b/lib/selecto_components/action_form_host.ex
@@ -62,17 +62,22 @@ defmodule SelectoComponents.ActionFormHost do
   end
 
   def update_component_assigns(socket, updates) when is_map(updates) do
-    modal_detail_data = Map.get(socket.assigns, :modal_detail_data, %{})
-    component_assigns = Map.get(modal_detail_data, :component_assigns, %{})
+    case Map.get(socket.assigns, :modal_detail_data) do
+      nil ->
+        socket
 
-    assign(socket,
-      modal_detail_data:
-        Map.put(
-          modal_detail_data,
-          :component_assigns,
-          Map.merge(component_assigns, updates)
+      modal_detail_data ->
+        component_assigns = Map.get(modal_detail_data, :component_assigns, %{})
+
+        assign(socket,
+          modal_detail_data:
+            Map.put(
+              modal_detail_data,
+              :component_assigns,
+              Map.merge(component_assigns, updates)
+            )
         )
-    )
+    end
   end
 
   defp call_action(callback, action_id, request, socket) when is_function(callback, 3),

--- a/lib/selecto_components/action_form_host.ex
+++ b/lib/selecto_components/action_form_host.ex
@@ -1,0 +1,119 @@
+defmodule SelectoComponents.ActionFormHost do
+  @moduledoc """
+  Host-side helpers for wiring `SelectoComponents.Modal.ActionFormModal`.
+
+  The modal owns form rendering and request construction. The host still owns
+  preview/apply execution, but can delegate the common LiveView state updates to
+  this module.
+  """
+
+  import Phoenix.Component, only: [assign: 2]
+
+  alias SelectoComponents.QueryContract
+
+  @doc """
+  Handles a `{:selecto_action_form_submit, payload}` message.
+
+  Required options:
+
+  - `:preview` - callback invoked as `(action_id, request, socket)`
+  - `:apply` - callback invoked as `(action_id, request, socket)`
+
+  Optional options:
+
+  - `:after_apply` - callback invoked as `(socket, result)` before modal result assignment
+  - `:format_error` - callback invoked as `(reason)` for host-specific error messages
+  """
+  def handle_submit(socket, %{intent: "apply"} = payload, opts) do
+    action_id = Map.fetch!(payload, :action_id)
+    request = Map.fetch!(payload, :request)
+
+    opts
+    |> Keyword.fetch!(:apply)
+    |> call_action(action_id, request, socket)
+    |> case do
+      {:ok, result} ->
+        socket =
+          opts
+          |> Keyword.get(:after_apply, &default_after_apply/2)
+          |> call_after_apply(socket, result)
+
+        {:noreply, assign_result(socket, "apply", result)}
+
+      {:error, reason} ->
+        {:noreply, assign_error(socket, error_message(reason, opts))}
+    end
+  end
+
+  def handle_submit(socket, payload, opts) when is_map(payload) do
+    action_id = Map.fetch!(payload, :action_id)
+    request = Map.fetch!(payload, :request)
+
+    opts
+    |> Keyword.fetch!(:preview)
+    |> call_action(action_id, request, socket)
+    |> case do
+      {:ok, result} ->
+        {:noreply, assign_result(socket, "preview", result)}
+
+      {:error, reason} ->
+        {:noreply, assign_error(socket, error_message(reason, opts))}
+    end
+  end
+
+  def assign_result(socket, intent, result) do
+    update_component_assigns(socket, %{
+      submitting: nil,
+      last_error: nil,
+      last_result: %{
+        "intent" => intent,
+        "payload" => QueryContract.json_safe(result)
+      }
+    })
+  end
+
+  def assign_error(socket, message) do
+    update_component_assigns(socket, %{
+      submitting: nil,
+      last_result: nil,
+      last_error: message
+    })
+  end
+
+  def update_component_assigns(socket, updates) when is_map(updates) do
+    modal_detail_data = Map.get(socket.assigns, :modal_detail_data, %{})
+    component_assigns = Map.get(modal_detail_data, :component_assigns, %{})
+
+    assign(socket,
+      modal_detail_data:
+        Map.put(
+          modal_detail_data,
+          :component_assigns,
+          Map.merge(component_assigns, updates)
+        )
+    )
+  end
+
+  defp call_action(callback, action_id, request, socket) when is_function(callback, 3),
+    do: callback.(action_id, request, socket)
+
+  defp call_action(callback, action_id, request, _socket) when is_function(callback, 2),
+    do: callback.(action_id, request)
+
+  defp call_after_apply(callback, socket, result) when is_function(callback, 2),
+    do: callback.(socket, result)
+
+  defp default_after_apply(socket, _result), do: socket
+
+  defp error_message(reason, opts) do
+    case Keyword.get(opts, :format_error) do
+      callback when is_function(callback, 1) -> callback.(reason)
+      _ -> default_error_message(reason)
+    end
+  end
+
+  defp default_error_message({:validation_error, message, _details}), do: message
+  defp default_error_message({:invalid_request, message}), do: message
+  defp default_error_message(reason) when is_binary(reason), do: reason
+  defp default_error_message(reason), do: inspect(reason)
+end

--- a/lib/selecto_components/actions.ex
+++ b/lib/selecto_components/actions.ex
@@ -26,6 +26,7 @@ defmodule SelectoComponents.Actions do
           required(:confirmation_message) => String.t() | nil,
           required(:reason) => String.t() | nil,
           required(:links) => map(),
+          required(:endpoints) => map(),
           required(:preview_link) => String.t() | nil,
           required(:apply_link) => String.t() | nil,
           required(:attrs) => map(),
@@ -215,6 +216,7 @@ defmodule SelectoComponents.Actions do
       confirmation_message: action_confirmation_message(action),
       reason: map_value(decision, :reason),
       links: action_links(action),
+      endpoints: action_endpoints(action),
       preview_link: action_link(action, "preview"),
       apply_link: action_link(action, "apply"),
       attrs: action_attrs(action, status),
@@ -249,8 +251,51 @@ defmodule SelectoComponents.Actions do
     action
     |> action_links()
     |> map_value(rel)
+    |> link_href()
     |> normalize_optional_id()
   end
+
+  defp action_endpoints(action) do
+    action
+    |> action_links()
+    |> Enum.reduce(%{}, fn {rel, link}, endpoints ->
+      rel = normalize_id(rel)
+
+      case action_endpoint(rel, link) do
+        nil -> endpoints
+        endpoint -> Map.put(endpoints, rel, endpoint)
+      end
+    end)
+  end
+
+  defp action_endpoint(rel, link) do
+    href = link_href(link) |> normalize_optional_id()
+
+    if href do
+      %{
+        "href" => href,
+        "method" => link_method(link),
+        "rel" => rel
+      }
+    end
+  end
+
+  defp link_href(link) when is_map(link) do
+    map_value(link, :href) ||
+      map_value(link, :url) ||
+      map_value(link, :path)
+  end
+
+  defp link_href(link), do: link
+
+  defp link_method(link) when is_map(link) do
+    link
+    |> map_value(:method, "POST")
+    |> normalize_id()
+    |> String.upcase()
+  end
+
+  defp link_method(_link), do: "POST"
 
   defp action_attrs(action, status) do
     %{

--- a/lib/selecto_components/actions.ex
+++ b/lib/selecto_components/actions.ex
@@ -61,6 +61,58 @@ defmodule SelectoComponents.Actions do
   end
 
   @doc """
+  Merges a decision extracted from an action preview/apply result.
+
+  Successful preview/apply payloads usually carry `capability_decision`; errors
+  can be converted into disabled decisions with their validation reason.
+  """
+  @spec put_result_decision(map(), term(), term()) :: map()
+  def put_result_decision(decisions, action_id, result) when is_map(decisions) do
+    Map.put(decisions, normalize_id(action_id), decision_from_result(result))
+  end
+
+  @doc """
+  Converts a preview/apply result into normalized decision metadata.
+  """
+  @spec decision_from_result(term()) :: map()
+  def decision_from_result({:ok, payload}), do: decision_from_result(payload)
+
+  def decision_from_result({:error, {:validation_error, message, details}}) do
+    details = map_or_empty(details)
+
+    %{
+      "status" => "disabled",
+      "reason" => message,
+      "code" => map_value(details, :code),
+      "metadata" => details
+    }
+    |> compact_decision()
+  end
+
+  def decision_from_result({:error, :not_found}) do
+    %{
+      "status" => "disabled",
+      "reason" => "Action target was not found.",
+      "code" => "not_found"
+    }
+  end
+
+  def decision_from_result({:error, reason}) do
+    %{
+      "status" => "disabled",
+      "reason" => inspect(reason)
+    }
+  end
+
+  def decision_from_result(payload) when is_map(payload) do
+    payload
+    |> result_capability_decision()
+    |> normalize_decision("enabled")
+  end
+
+  def decision_from_result(_payload), do: normalize_decision(:enabled, "enabled")
+
+  @doc """
   Returns the decision for an action entry from action id or capability id.
   """
   @spec decision_for(map(), map(), String.t()) :: map()
@@ -198,6 +250,22 @@ defmodule SelectoComponents.Actions do
   end
 
   defp normalize_decision(_decision, default_status), do: normalize_decision(nil, default_status)
+
+  defp result_capability_decision(payload) do
+    map_value(payload, :capability_decision) ||
+      payload
+      |> map_value(:preview, %{})
+      |> map_value(:capability_decision) ||
+      payload
+      |> map_value(:result, %{})
+      |> map_value(:capability_decision)
+  end
+
+  defp compact_decision(decision) do
+    decision
+    |> Enum.reject(fn {_key, value} -> is_nil(value) or value == %{} end)
+    |> Map.new()
+  end
 
   defp normalize_status(status) when status in [:enabled, "enabled"], do: "enabled"
   defp normalize_status(status) when status in [:disabled, "disabled"], do: "disabled"

--- a/lib/selecto_components/actions.ex
+++ b/lib/selecto_components/actions.ex
@@ -22,6 +22,8 @@ defmodule SelectoComponents.Actions do
           required(:hidden?) => boolean(),
           required(:destructive?) => boolean(),
           required(:requires_confirmation?) => boolean(),
+          required(:confirmation) => map(),
+          required(:confirmation_message) => String.t() | nil,
           required(:reason) => String.t() | nil,
           required(:links) => map(),
           required(:preview_link) => String.t() | nil,
@@ -194,6 +196,8 @@ defmodule SelectoComponents.Actions do
       hidden?: status == "hidden",
       destructive?: destructive_action?(action),
       requires_confirmation?: requires_confirmation?(action),
+      confirmation: action_confirmation(action),
+      confirmation_message: action_confirmation_message(action),
       reason: map_value(decision, :reason),
       links: action_links(action),
       preview_link: action_link(action, "preview"),
@@ -258,11 +262,24 @@ defmodule SelectoComponents.Actions do
   end
 
   defp requires_confirmation?(action) do
-    confirmation = action |> map_value(:confirmation, %{}) |> map_or_empty()
+    confirmation = action_confirmation(action)
 
     truthy?(map_value(action, :requires_confirmation)) ||
       truthy?(map_value(confirmation, :required)) ||
       truthy?(map_value(confirmation, :enabled))
+  end
+
+  defp action_confirmation(action) do
+    action
+    |> map_value(:confirmation, %{})
+    |> map_or_empty()
+  end
+
+  defp action_confirmation_message(action) do
+    action
+    |> action_confirmation()
+    |> map_value(:message)
+    |> normalize_optional_id()
   end
 
   defp normalize_decision(nil, default_status),

--- a/lib/selecto_components/actions.ex
+++ b/lib/selecto_components/actions.ex
@@ -181,6 +181,101 @@ defmodule SelectoComponents.Actions do
     |> maybe_put("confirmed", Keyword.get(opts, :confirmed))
   end
 
+  @doc """
+  Normalizes one domain action for use by `ActionFormModal`.
+
+  This is the bridge for host apps that already have a domain action contract
+  and only need a Selecto Components form shell. `:endpoint_base` can be passed
+  to derive standard preview/apply endpoints from the action id.
+  """
+  @spec form_action(map(), keyword()) :: action_item() | nil
+  def form_action(action, opts \\ [])
+
+  def form_action(action, opts) when is_map(action) do
+    action =
+      action
+      |> map_or_empty()
+      |> maybe_put_new_id(Keyword.get(opts, :id))
+      |> put_endpoint_base(Keyword.get(opts, :endpoint_base))
+      |> put_links(Keyword.get(opts, :links))
+
+    decisions =
+      case Keyword.get(opts, :decision) do
+        nil -> %{}
+        decision -> %{(action |> map_value(:id) |> normalize_id()) => decision}
+      end
+
+    %{"actions" => [action]}
+    |> available(
+      decisions: Keyword.get(opts, :decisions, decisions),
+      default_status: Keyword.get(opts, :default_status, "enabled")
+    )
+    |> List.first()
+  end
+
+  def form_action(_action, _opts), do: nil
+
+  @doc """
+  Builds assign data for `SelectoComponents.Modal.ActionFormModal`.
+  """
+  @spec form_assigns(map(), keyword()) :: map()
+  def form_assigns(action, opts \\ []) when is_map(action) do
+    %{
+      target: Keyword.get(opts, :target, %{id: {:field, "id"}}),
+      action: form_action(action, opts)
+    }
+  end
+
+  @doc """
+  Builds a detail-action config that opens a domain action as an action form.
+  """
+  @spec detail_action(map(), keyword()) :: map()
+  def detail_action(action, opts \\ []) when is_map(action) do
+    form_action = form_action(action, opts) || %{}
+    label = map_value(form_action, :label, "Action")
+
+    %{
+      name: Keyword.get(opts, :name, map_value(form_action, :label)),
+      description:
+        Keyword.get(
+          opts,
+          :description,
+          "Open #{map_value(form_action, :label, "this action")} as a Selecto Components form."
+        ),
+      type: :live_component,
+      required_fields: Keyword.get(opts, :required_fields, [:id]),
+      payload: %{
+        title: Keyword.get(opts, :title, label <> " #" <> "{{id}}"),
+        module: Keyword.get(opts, :module, SelectoComponents.Modal.ActionFormModal),
+        size: Keyword.get(opts, :size, :lg),
+        navigation_enabled: Keyword.get(opts, :navigation_enabled, true),
+        assigns: %{
+          target: Keyword.get(opts, :target, %{id: {:field, "id"}}),
+          action: form_action
+        }
+      }
+    }
+  end
+
+  @doc """
+  Builds a map of generated detail-action configs for all visible actions.
+  """
+  @spec detail_actions(term(), keyword()) :: map()
+  def detail_actions(contract, opts \\ []) do
+    prefix = opts |> Keyword.get(:id_prefix, "action_form_") |> normalize_id()
+
+    contract
+    |> action_entries()
+    |> Enum.flat_map(fn action ->
+      case form_action(action, opts) do
+        nil -> []
+        form_action -> [{prefix <> form_action.id, detail_action(form_action.contract, opts)}]
+      end
+    end)
+    |> Enum.reject(fn {_id, config} -> is_nil(get_in(config, [:payload, :assigns, :action])) end)
+    |> Map.new()
+  end
+
   defp action_entries(contract) when is_map(contract) do
     case map_value(contract, :actions) do
       actions when is_list(actions) -> actions
@@ -199,6 +294,42 @@ defmodule SelectoComponents.Actions do
       |> Map.put_new(:id, id)
     end)
   end
+
+  defp maybe_put_new_id(action, nil), do: action
+  defp maybe_put_new_id(action, id), do: Map.put_new(action, "id", normalize_id(id))
+
+  defp put_endpoint_base(action, nil), do: action
+
+  defp put_endpoint_base(action, endpoint_base) do
+    action_id = action |> map_value(:id) |> normalize_id()
+    endpoint_base = endpoint_base |> normalize_id() |> String.trim_trailing("/")
+
+    generated_links =
+      if action_id == "" or endpoint_base == "" do
+        %{}
+      else
+        %{
+          "preview" => "#{endpoint_base}/#{action_id}/preview",
+          "apply" => "#{endpoint_base}/#{action_id}/apply"
+        }
+      end
+
+    put_links(action, generated_links)
+  end
+
+  defp put_links(action, nil), do: action
+
+  defp put_links(action, links) when is_map(links) do
+    current_links =
+      action
+      |> map_value(:links, %{})
+      |> map_or_empty()
+      |> stringify_map_keys()
+
+    Map.put(action, "links", Map.merge(links, current_links))
+  end
+
+  defp put_links(action, _links), do: action
 
   defp action_item(action, decisions, default_status) do
     action = SelectoComponents.QueryContract.json_safe(map_or_empty(action))
@@ -500,6 +631,10 @@ defmodule SelectoComponents.Actions do
 
   defp map_or_empty(map) when is_map(map), do: map
   defp map_or_empty(_value), do: %{}
+
+  defp stringify_map_keys(map) when is_map(map) do
+    Map.new(map, fn {key, value} -> {normalize_id(key), value} end)
+  end
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)

--- a/lib/selecto_components/actions.ex
+++ b/lib/selecto_components/actions.ex
@@ -159,6 +159,21 @@ defmodule SelectoComponents.Actions do
     end)
   end
 
+  @doc """
+  Builds a portable action request template for preview/apply/availability calls.
+  """
+  @spec request_template(map(), keyword()) :: map()
+  def request_template(action, opts \\ []) when is_map(action) do
+    target = Keyword.get(opts, :target, %{"id" => ""})
+
+    %{
+      "action" => action |> map_value(:id) |> normalize_id(),
+      "target" => SelectoComponents.QueryContract.json_safe(target)
+    }
+    |> maybe_put("dry_run", Keyword.get(opts, :dry_run))
+    |> maybe_put("confirmed", Keyword.get(opts, :confirmed))
+  end
+
   defp action_entries(contract) when is_map(contract) do
     case map_value(contract, :actions) do
       actions when is_list(actions) -> actions
@@ -344,6 +359,9 @@ defmodule SelectoComponents.Actions do
 
   defp map_or_empty(map) when is_map(map), do: map
   defp map_or_empty(_value), do: %{}
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp truthy?(value) when value in [true, "true", "1", 1, true, :yes], do: true
   defp truthy?(_value), do: false

--- a/lib/selecto_components/actions.ex
+++ b/lib/selecto_components/actions.ex
@@ -276,6 +276,39 @@ defmodule SelectoComponents.Actions do
     |> Map.new()
   end
 
+  @doc """
+  Builds generated action-form configs for bulk action surfaces.
+
+  This mirrors `detail_actions/2`, but filters to domain actions whose
+  normalized scope is `"bulk"` and defaults the target template to selected row
+  ids. The returned configs intentionally use the same modal payload shape so
+  hosts can route bulk preview/apply through `ActionFormHost`.
+  """
+  @spec bulk_actions(term(), keyword()) :: map()
+  def bulk_actions(contract, opts \\ []) do
+    opts =
+      opts
+      |> Keyword.put_new(:id_prefix, "bulk_action_form_")
+      |> Keyword.put_new(:required_fields, [])
+      |> Keyword.put_new(:target, %{ids: {:selection, "ids"}})
+
+    prefix = opts |> Keyword.fetch!(:id_prefix) |> normalize_id()
+
+    contract
+    |> action_entries()
+    |> Enum.flat_map(fn action ->
+      case form_action(action, opts) do
+        %{scope: "bulk"} = form_action ->
+          [{prefix <> form_action.id, detail_action(form_action.contract, opts)}]
+
+        _other ->
+          []
+      end
+    end)
+    |> Enum.reject(fn {_id, config} -> is_nil(get_in(config, [:payload, :assigns, :action])) end)
+    |> Map.new()
+  end
+
   defp action_entries(contract) when is_map(contract) do
     case map_value(contract, :actions) do
       actions when is_list(actions) -> actions

--- a/lib/selecto_components/actions.ex
+++ b/lib/selecto_components/actions.ex
@@ -128,6 +128,35 @@ defmodule SelectoComponents.Actions do
     normalize_decision(decision, default_status)
   end
 
+  @doc """
+  Counts visible action items by normalized status.
+  """
+  @spec status_counts([action_item()]) :: map()
+  def status_counts(actions) when is_list(actions) do
+    actions
+    |> Enum.reduce(%{"enabled" => 0, "disabled" => 0}, fn action, counts ->
+      status =
+        action
+        |> map_value(:status, "enabled")
+        |> normalize_status()
+
+      Map.update(counts, status, 1, &(&1 + 1))
+    end)
+  end
+
+  @doc """
+  Groups visible action items by scope, using `"unscoped"` when no scope exists.
+  """
+  @spec by_scope([action_item()]) :: map()
+  def by_scope(actions) when is_list(actions) do
+    Enum.group_by(actions, fn action ->
+      action
+      |> map_value(:scope)
+      |> normalize_optional_id()
+      |> Kernel.||("unscoped")
+    end)
+  end
+
   defp action_entries(contract) when is_map(contract) do
     case map_value(contract, :actions) do
       actions when is_list(actions) -> actions

--- a/lib/selecto_components/actions.ex
+++ b/lib/selecto_components/actions.ex
@@ -24,6 +24,10 @@ defmodule SelectoComponents.Actions do
           required(:requires_confirmation?) => boolean(),
           required(:confirmation) => map(),
           required(:confirmation_message) => String.t() | nil,
+          required(:inputs) => [map()],
+          required(:input_template) => map(),
+          required(:required_inputs) => [String.t()],
+          required(:variants) => [map()],
           required(:reason) => String.t() | nil,
           required(:links) => map(),
           required(:endpoints) => map(),
@@ -166,11 +170,13 @@ defmodule SelectoComponents.Actions do
   @spec request_template(map(), keyword()) :: map()
   def request_template(action, opts \\ []) when is_map(action) do
     target = Keyword.get(opts, :target, %{"id" => ""})
+    inputs = Keyword.get(opts, :inputs, action_input_template(action))
 
     %{
       "action" => action |> map_value(:id) |> normalize_id(),
       "target" => SelectoComponents.QueryContract.json_safe(target)
     }
+    |> maybe_put("inputs", empty_to_nil(SelectoComponents.QueryContract.json_safe(inputs)))
     |> maybe_put("dry_run", Keyword.get(opts, :dry_run))
     |> maybe_put("confirmed", Keyword.get(opts, :confirmed))
   end
@@ -214,6 +220,10 @@ defmodule SelectoComponents.Actions do
       requires_confirmation?: requires_confirmation?(action),
       confirmation: action_confirmation(action),
       confirmation_message: action_confirmation_message(action),
+      inputs: action_inputs(action),
+      input_template: action_input_template(action),
+      required_inputs: action_required_inputs(action),
+      variants: action_variants(action),
       reason: map_value(decision, :reason),
       links: action_links(action),
       endpoints: action_endpoints(action),
@@ -342,6 +352,92 @@ defmodule SelectoComponents.Actions do
     |> normalize_optional_id()
   end
 
+  defp action_inputs(action) do
+    action
+    |> map_value(:inputs, [])
+    |> normalize_input_entries()
+  end
+
+  defp action_variants(action) do
+    action
+    |> map_value(:variants, [])
+    |> normalize_variant_entries()
+  end
+
+  defp normalize_input_entries(inputs) when is_list(inputs) do
+    inputs
+    |> Enum.map(&map_or_empty/1)
+    |> Enum.reject(&(&1 == %{}))
+  end
+
+  defp normalize_input_entries(inputs) when is_map(inputs) do
+    inputs
+    |> Enum.map(fn {id, input} ->
+      input
+      |> map_or_empty()
+      |> Map.put_new("id", normalize_id(id))
+    end)
+  end
+
+  defp normalize_input_entries(_inputs), do: []
+
+  defp normalize_variant_entries(variants) when is_list(variants) do
+    variants
+    |> Enum.map(fn variant ->
+      variant = map_or_empty(variant)
+      Map.update(variant, "inputs", [], &normalize_input_entries/1)
+    end)
+    |> Enum.reject(&(&1 == %{}))
+  end
+
+  defp normalize_variant_entries(variants) when is_map(variants) do
+    variants
+    |> Enum.map(fn {id, variant} ->
+      variant
+      |> map_or_empty()
+      |> Map.put_new("id", normalize_id(id))
+      |> Map.update("inputs", [], &normalize_input_entries/1)
+    end)
+  end
+
+  defp normalize_variant_entries(_variants), do: []
+
+  defp action_input_template(action) do
+    action
+    |> action_inputs()
+    |> input_template()
+  end
+
+  defp input_template(inputs) do
+    inputs
+    |> Enum.map(fn input ->
+      {input |> map_value(:id) |> normalize_id(), input_default(input)}
+    end)
+    |> Enum.reject(fn {id, _value} -> id == "" end)
+    |> Map.new()
+  end
+
+  defp input_default(input) do
+    cond do
+      present?(map_value(input, :default)) ->
+        map_value(input, :default)
+
+      input |> map_value(:type) |> normalize_id() == "collection" ->
+        []
+
+      true ->
+        ""
+    end
+  end
+
+  defp action_required_inputs(action) do
+    action
+    |> action_inputs()
+    |> Enum.filter(&(map_value(&1, :required) |> truthy?()))
+    |> Enum.map(&(map_value(&1, :id) |> normalize_id()))
+    |> Enum.reject(&(&1 == ""))
+  end
+
   defp normalize_decision(nil, default_status),
     do: %{"status" => normalize_status(default_status)}
 
@@ -407,6 +503,11 @@ defmodule SelectoComponents.Actions do
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp empty_to_nil(value) when value in [%{}, []], do: nil
+  defp empty_to_nil(value), do: value
+
+  defp present?(value), do: not is_nil(value)
 
   defp truthy?(value) when value in [true, "true", "1", 1, true, :yes], do: true
   defp truthy?(_value), do: false

--- a/lib/selecto_components/actions.ex
+++ b/lib/selecto_components/actions.ex
@@ -1,0 +1,177 @@
+defmodule SelectoComponents.Actions do
+  @moduledoc """
+  Components-facing helpers for domain action contracts.
+
+  This module adapts Updato-style write contract `actions` into stable UI items
+  without depending on `selecto_updato`. Callers can pass a write contract
+  document and optional capability decisions from preview/apply responses.
+  Hidden actions are removed, disabled actions are retained with reason
+  metadata, and enabled actions carry their preview/apply links.
+  """
+
+  @type action_item :: %{
+          required(:id) => String.t(),
+          required(:label) => String.t(),
+          required(:scope) => String.t() | nil,
+          required(:operation) => String.t() | nil,
+          required(:capability) => String.t() | nil,
+          required(:status) => String.t(),
+          required(:disabled?) => boolean(),
+          required(:hidden?) => boolean(),
+          required(:reason) => String.t() | nil,
+          required(:links) => map(),
+          required(:contract) => map()
+        }
+
+  @doc """
+  Returns action items suitable for row/global/bulk action renderers.
+
+  Options:
+
+  - `:scope` filters actions to a scope such as `:row` or `"bulk"`
+  - `:decisions` supplies `%{"action_id" => decision}` or `%{"capability" => decision}`
+  - `:default_status` defaults to `"enabled"`
+  """
+  @spec available(term(), keyword()) :: [action_item()]
+  def available(contract, opts \\ []) do
+    scope = opts |> Keyword.get(:scope) |> normalize_optional_id()
+    decisions = Keyword.get(opts, :decisions, %{})
+    default_status = opts |> Keyword.get(:default_status, "enabled") |> normalize_status()
+
+    contract
+    |> action_entries()
+    |> Enum.map(&action_item(&1, decisions, default_status))
+    |> Enum.reject(& &1.hidden?)
+    |> Enum.filter(fn item -> is_nil(scope) or item.scope == scope end)
+  end
+
+  @doc """
+  Merges a new preview/apply capability decision into an existing decision map.
+  """
+  @spec put_decision(map(), term(), map()) :: map()
+  def put_decision(decisions, action_id, decision) when is_map(decisions) and is_map(decision) do
+    Map.put(decisions, normalize_id(action_id), normalize_decision(decision, "enabled"))
+  end
+
+  @doc """
+  Returns the decision for an action entry from action id or capability id.
+  """
+  @spec decision_for(map(), map(), String.t()) :: map()
+  def decision_for(action, decisions, default_status \\ "enabled") do
+    action_id = action |> map_value(:id) |> normalize_id()
+    capability = action |> map_value(:capability) |> normalize_optional_id()
+
+    decision =
+      map_lookup(decisions, action_id) ||
+        map_lookup(decisions, capability) ||
+        map_value(action, :capability_decision)
+
+    normalize_decision(decision, default_status)
+  end
+
+  defp action_entries(contract) when is_map(contract) do
+    case map_value(contract, :actions) do
+      actions when is_list(actions) -> actions
+      actions when is_map(actions) -> map_actions(actions)
+      _ -> []
+    end
+  end
+
+  defp action_entries(_contract), do: []
+
+  defp map_actions(actions) do
+    actions
+    |> Enum.map(fn {id, action} ->
+      action
+      |> map_or_empty()
+      |> Map.put_new(:id, id)
+    end)
+  end
+
+  defp action_item(action, decisions, default_status) do
+    action = SelectoComponents.QueryContract.json_safe(map_or_empty(action))
+    decision = decision_for(action, decisions, default_status)
+    status = normalize_status(map_value(decision, :status))
+
+    %{
+      id: action |> map_value(:id) |> normalize_id(),
+      label: action_label(action),
+      scope: action |> map_value(:scope) |> normalize_optional_id(),
+      operation: action_operation(action),
+      capability: action |> map_value(:capability) |> normalize_optional_id(),
+      status: status,
+      disabled?: status == "disabled",
+      hidden?: status == "hidden",
+      reason: map_value(decision, :reason),
+      links: action_links(action),
+      contract: action
+    }
+  end
+
+  defp action_label(action) do
+    map_value(action, :label) ||
+      map_value(action, :name) ||
+      action
+      |> map_value(:id)
+      |> normalize_id()
+      |> String.replace("_", " ")
+      |> String.capitalize()
+  end
+
+  defp action_operation(action) do
+    action
+    |> map_value(:execution, %{})
+    |> map_value(:operation)
+    |> normalize_optional_id()
+  end
+
+  defp action_links(action) do
+    action
+    |> map_value(:links, %{})
+    |> map_or_empty()
+  end
+
+  defp normalize_decision(nil, default_status),
+    do: %{"status" => normalize_status(default_status)}
+
+  defp normalize_decision(status, _default_status) when is_atom(status) or is_binary(status) do
+    %{"status" => normalize_status(status)}
+  end
+
+  defp normalize_decision(decision, default_status) when is_map(decision) do
+    decision
+    |> SelectoComponents.QueryContract.json_safe()
+    |> Map.put_new("status", normalize_status(default_status))
+  end
+
+  defp normalize_decision(_decision, default_status), do: normalize_decision(nil, default_status)
+
+  defp normalize_status(status) when status in [:enabled, "enabled"], do: "enabled"
+  defp normalize_status(status) when status in [:disabled, "disabled"], do: "disabled"
+  defp normalize_status(status) when status in [:hidden, "hidden"], do: "hidden"
+  defp normalize_status(_status), do: "enabled"
+
+  defp normalize_id(nil), do: ""
+  defp normalize_id(value) when is_atom(value), do: Atom.to_string(value)
+  defp normalize_id(value) when is_binary(value), do: value
+  defp normalize_id(value), do: to_string(value)
+
+  defp normalize_optional_id(nil), do: nil
+  defp normalize_optional_id(""), do: nil
+  defp normalize_optional_id(value), do: normalize_id(value)
+
+  defp map_lookup(_map, nil), do: nil
+  defp map_lookup(_map, ""), do: nil
+  defp map_lookup(map, key) when is_map(map), do: Map.get(map, key, Map.get(map, to_string(key)))
+  defp map_lookup(_map, _key), do: nil
+
+  defp map_value(map, key, default \\ nil)
+
+  defp map_value(map, key, default) when is_map(map) and is_atom(key),
+    do: Map.get(map, key, Map.get(map, Atom.to_string(key), default))
+
+  defp map_value(_map, _key, default), do: default
+
+  defp map_or_empty(map) when is_map(map), do: map
+  defp map_or_empty(_value), do: %{}
+end

--- a/lib/selecto_components/actions.ex
+++ b/lib/selecto_components/actions.ex
@@ -299,7 +299,8 @@ defmodule SelectoComponents.Actions do
     |> Enum.flat_map(fn action ->
       case form_action(action, opts) do
         %{scope: "bulk"} = form_action ->
-          [{prefix <> form_action.id, detail_action(form_action.contract, opts)}]
+          config_opts = Keyword.put_new(opts, :title, form_action.label)
+          [{prefix <> form_action.id, detail_action(form_action.contract, config_opts)}]
 
         _other ->
           []

--- a/lib/selecto_components/actions.ex
+++ b/lib/selecto_components/actions.ex
@@ -12,14 +12,21 @@ defmodule SelectoComponents.Actions do
   @type action_item :: %{
           required(:id) => String.t(),
           required(:label) => String.t(),
+          required(:description) => String.t() | nil,
           required(:scope) => String.t() | nil,
           required(:operation) => String.t() | nil,
           required(:capability) => String.t() | nil,
+          required(:icon) => String.t() | nil,
           required(:status) => String.t(),
           required(:disabled?) => boolean(),
           required(:hidden?) => boolean(),
+          required(:destructive?) => boolean(),
+          required(:requires_confirmation?) => boolean(),
           required(:reason) => String.t() | nil,
           required(:links) => map(),
+          required(:preview_link) => String.t() | nil,
+          required(:apply_link) => String.t() | nil,
+          required(:attrs) => map(),
           required(:contract) => map()
         }
 
@@ -96,14 +103,21 @@ defmodule SelectoComponents.Actions do
     %{
       id: action |> map_value(:id) |> normalize_id(),
       label: action_label(action),
+      description: action |> map_value(:description) |> normalize_optional_id(),
       scope: action |> map_value(:scope) |> normalize_optional_id(),
       operation: action_operation(action),
       capability: action |> map_value(:capability) |> normalize_optional_id(),
+      icon: action |> map_value(:icon) |> normalize_optional_id(),
       status: status,
       disabled?: status == "disabled",
       hidden?: status == "hidden",
+      destructive?: destructive_action?(action),
+      requires_confirmation?: requires_confirmation?(action),
       reason: map_value(decision, :reason),
       links: action_links(action),
+      preview_link: action_link(action, "preview"),
+      apply_link: action_link(action, "apply"),
+      attrs: action_attrs(action, status),
       contract: action
     }
   end
@@ -129,6 +143,45 @@ defmodule SelectoComponents.Actions do
     action
     |> map_value(:links, %{})
     |> map_or_empty()
+  end
+
+  defp action_link(action, rel) do
+    action
+    |> action_links()
+    |> map_value(rel)
+    |> normalize_optional_id()
+  end
+
+  defp action_attrs(action, status) do
+    %{
+      "data-action-id" => action |> map_value(:id) |> normalize_id(),
+      "data-action-status" => status,
+      "data-action-scope" => action |> map_value(:scope) |> normalize_optional_id(),
+      "data-action-capability" => action |> map_value(:capability) |> normalize_optional_id(),
+      "data-action-operation" => action_operation(action),
+      "data-action-confirmation" => requires_confirmation?(action),
+      "data-action-destructive" => destructive_action?(action)
+    }
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  defp destructive_action?(action) do
+    presentation = action |> map_value(:presentation, %{}) |> map_or_empty()
+    confirmation = action |> map_value(:confirmation, %{}) |> map_or_empty()
+
+    truthy?(map_value(action, :destructive)) ||
+      truthy?(map_value(presentation, :destructive)) ||
+      truthy?(map_value(confirmation, :destructive)) ||
+      action_operation(action) in ["delete", "soft_delete"]
+  end
+
+  defp requires_confirmation?(action) do
+    confirmation = action |> map_value(:confirmation, %{}) |> map_or_empty()
+
+    truthy?(map_value(action, :requires_confirmation)) ||
+      truthy?(map_value(confirmation, :required)) ||
+      truthy?(map_value(confirmation, :enabled))
   end
 
   defp normalize_decision(nil, default_status),
@@ -170,8 +223,14 @@ defmodule SelectoComponents.Actions do
   defp map_value(map, key, default) when is_map(map) and is_atom(key),
     do: Map.get(map, key, Map.get(map, Atom.to_string(key), default))
 
+  defp map_value(map, key, default) when is_map(map) and is_binary(key),
+    do: Map.get(map, key, default)
+
   defp map_value(_map, _key, default), do: default
 
   defp map_or_empty(map) when is_map(map), do: map
   defp map_or_empty(_value), do: %{}
+
+  defp truthy?(value) when value in [true, "true", "1", 1, true, :yes], do: true
+  defp truthy?(_value), do: false
 end

--- a/lib/selecto_components/enhanced_table/bulk_actions.ex
+++ b/lib/selecto_components/enhanced_table/bulk_actions.ex
@@ -4,6 +4,7 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
   """
 
   use Phoenix.LiveComponent
+  alias SelectoComponents.Actions
   alias SelectoComponents.EnhancedTable.RowSelection
   alias Phoenix.LiveView.JS
 
@@ -31,7 +32,11 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
 
   @impl true
   def update(assigns, socket) do
-    actions = assigns[:actions] || default_actions()
+    actions =
+      (assigns[:actions] || default_actions())
+      |> Kernel.++(generated_action_forms(assigns))
+      |> Enum.map(&normalize_action_item/1)
+      |> Enum.reject(&is_nil/1)
 
     socket =
       socket
@@ -324,6 +329,9 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
         phx-click="execute_action"
         phx-value-action={@action.id}
         phx-target={@myself}
+        data-bulk-action-id={@action.id}
+        data-bulk-action-source={Map.get(@action, :source)}
+        data-bulk-action-scope={Map.get(@action, :scope)}
       >
         <%= if icon = safe_icon(@action.icon) do %>
           <span class={@action.icon_class || "text-gray-500"}>
@@ -350,17 +358,22 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
   def handle_event("execute_action", %{"action" => action_id}, socket) do
     action = Enum.find(socket.assigns.actions, &(&1.id == action_id))
 
-    if action && action.requires_confirmation do
-      {:noreply,
-       socket
-       |> assign(
-         show_confirmation: true,
-         confirmation_message:
-           action.confirmation_message || "Are you sure you want to perform this action?",
-         bulk_action: action
-       )}
-    else
-      {:noreply, execute_bulk_action(socket, action)}
+    cond do
+      generated_action_form?(action) ->
+        {:noreply, open_generated_action_form(socket, action)}
+
+      action && action.requires_confirmation ->
+        {:noreply,
+         socket
+         |> assign(
+           show_confirmation: true,
+           confirmation_message:
+             action.confirmation_message || "Are you sure you want to perform this action?",
+           bulk_action: action
+         )}
+
+      true ->
+        {:noreply, execute_bulk_action(socket, action)}
     end
   end
 
@@ -410,6 +423,81 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
     all_ids = get_all_row_ids(socket)
     {:noreply, RowSelection.select_range(socket, from_id, to_id, all_ids)}
   end
+
+  defp open_generated_action_form(socket, action) do
+    selected_ids = RowSelection.get_selected_ids(socket)
+
+    if selected_ids == [] do
+      socket
+    else
+      payload = Map.get(action, :payload, %{})
+      component_assigns_template = Map.get(payload, :assigns, %{})
+      selection_context = %{"ids" => selected_ids, "count" => length(selected_ids)}
+      component_assigns = resolve_selection_assigns(component_assigns_template, selection_context)
+
+      send(
+        self(),
+        {:show_detail_modal,
+         %{
+           action_id: action.id,
+           action_source: :generated_bulk_action_form,
+           action_type: :live_component,
+           record: selection_context,
+           current_index: 0,
+           total_records: length(selected_ids),
+           records: [selection_context],
+           fields: ["ids", "count"],
+           related_data: %{},
+           title: Map.get(payload, :title, action.label),
+           title_template: Map.get(payload, :title),
+           size: Map.get(payload, :size, :lg),
+           navigation_enabled: false,
+           edit_enabled: false,
+           component_module: Map.get(payload, :module),
+           component_assigns_template: component_assigns_template,
+           component_assigns: component_assigns
+         }}
+      )
+
+      assign(socket, bulk_action: action)
+    end
+  end
+
+  defp generated_action_form?(%{source: :generated_bulk_action_form}), do: true
+  defp generated_action_form?(_action), do: false
+
+  defp resolve_selection_assigns(assigns_template, selection_context)
+       when is_map(assigns_template) do
+    Map.new(assigns_template, fn {key, value} ->
+      {key, resolve_selection_value(value, selection_context)}
+    end)
+  end
+
+  defp resolve_selection_assigns(_assigns_template, _selection_context), do: %{}
+
+  defp resolve_selection_value({:selection, key}, selection_context) do
+    Map.get(selection_context, to_string(key))
+  end
+
+  defp resolve_selection_value(%{selection: key}, selection_context) do
+    resolve_selection_value({:selection, key}, selection_context)
+  end
+
+  defp resolve_selection_value(%{"selection" => key}, selection_context) do
+    resolve_selection_value({:selection, key}, selection_context)
+  end
+
+  defp resolve_selection_value(value, selection_context) when is_list(value) do
+    Enum.map(value, &resolve_selection_value(&1, selection_context))
+  end
+
+  defp resolve_selection_value(value, selection_context) when is_map(value) do
+    Map.new(value, fn {key, nested_value} ->
+      {key, resolve_selection_value(nested_value, selection_context)}
+    end)
+  end
+
+  defp resolve_selection_value(value, _selection_context), do: value
 
   # Bulk action execution
 
@@ -623,6 +711,81 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
   end
 
   defp safe_icon(_icon), do: nil
+
+  defp generated_action_forms(assigns) do
+    assigns
+    |> generated_action_contract()
+    |> Actions.bulk_actions(id_prefix: "domain_bulk_action_form_")
+    |> Enum.map(fn {id, config} -> generated_action_form_menu_item(id, config) end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp generated_action_contract(assigns) do
+    assigns[:action_contract] ||
+      assigns[:write_contract] ||
+      assigns[:domain] ||
+      case assigns[:selecto] do
+        nil -> %{}
+        selecto -> Selecto.domain(selecto)
+      end
+  end
+
+  defp generated_action_form_menu_item(id, config) when is_map(config) do
+    payload = Map.get(config, :payload, %{})
+    action = get_in(payload, [:assigns, :action]) || %{}
+
+    %{
+      id: id,
+      label: Map.get(config, :name) || map_value(action, :label) || id,
+      description: Map.get(config, :description),
+      source: :generated_bulk_action_form,
+      scope: "bulk",
+      type: :live_component,
+      payload: payload,
+      quick_action: false,
+      requires_confirmation: false,
+      confirmation_message: map_value(action, :confirmation_message)
+    }
+  end
+
+  defp generated_action_form_menu_item(_id, _config), do: nil
+
+  defp normalize_action_item(action) when is_map(action) do
+    %{
+      id: map_value(action, :id),
+      label: map_value(action, :label),
+      description: map_value(action, :description),
+      icon: map_value(action, :icon),
+      icon_class: map_value(action, :icon_class),
+      text_class: map_value(action, :text_class),
+      badge: map_value(action, :badge),
+      divider: truthy?(map_value(action, :divider)),
+      quick_action: truthy?(map_value(action, :quick_action)),
+      requires_confirmation: truthy?(map_value(action, :requires_confirmation)),
+      confirmation_message: map_value(action, :confirmation_message),
+      source: map_value(action, :source),
+      scope: map_value(action, :scope),
+      type: map_value(action, :type),
+      payload: map_value(action, :payload, %{}),
+      batch_size: map_value(action, :batch_size),
+      handler: map_value(action, :handler)
+    }
+  end
+
+  defp normalize_action_item(_action), do: nil
+
+  defp map_value(map, key, default \\ nil)
+
+  defp map_value(map, key, default) when is_map(map) and is_atom(key),
+    do: Map.get(map, key, Map.get(map, Atom.to_string(key), default))
+
+  defp map_value(map, key, default) when is_map(map) and is_binary(key),
+    do: Map.get(map, key, default)
+
+  defp map_value(_map, _key, default), do: default
+
+  defp truthy?(value) when value in [true, "true", "1", 1, :yes], do: true
+  defp truthy?(_value), do: false
 
   defp default_actions do
     [

--- a/lib/selecto_components/enhanced_table/bulk_actions.ex
+++ b/lib/selecto_components/enhanced_table/bulk_actions.ex
@@ -1,6 +1,11 @@
 defmodule SelectoComponents.EnhancedTable.BulkActions do
   @moduledoc """
   Bulk actions interface for performing operations on multiple selected records.
+
+  Bulk actions should come from domain action contracts and render as generated
+  `ActionFormModal` entries. Passing explicit `:actions` is a deprecated
+  pre-1.0 compatibility path kept only while the remaining callers move to
+  domain actions; do not add new behavior there.
   """
 
   use Phoenix.LiveComponent
@@ -33,7 +38,7 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
   @impl true
   def update(assigns, socket) do
     actions =
-      (assigns[:actions] || default_actions())
+      (assigns[:actions] || [])
       |> Kernel.++(generated_action_forms(assigns))
       |> Enum.map(&normalize_action_item/1)
       |> Enum.reject(&is_nil/1)
@@ -504,7 +509,12 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
 
   defp resolve_selection_value(value, _selection_context), do: value
 
-  # Bulk action execution
+  # Deprecated explicit-action execution path.
+  #
+  # Domain actions should render generated action-form menu items and run through
+  # `ActionFormModal` + `ActionFormHost`. Keep this small and removable; it is
+  # only present to keep explicit `actions:` assigns parent-safe until it is
+  # deleted before 1.0.
 
   defp execute_bulk_action(socket, nil), do: socket
 
@@ -737,7 +747,7 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
       quick_action: truthy?(map_value(action, :quick_action)),
       requires_confirmation: truthy?(map_value(action, :requires_confirmation)),
       confirmation_message: map_value(action, :confirmation_message),
-      source: map_value(action, :source),
+      source: map_value(action, :source) || :deprecated_explicit_bulk_action,
       scope: map_value(action, :scope),
       type: map_value(action, :type),
       payload: map_value(action, :payload, %{}),
@@ -760,47 +770,6 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
 
   defp truthy?(value) when value in [true, "true", "1", 1, :yes], do: true
   defp truthy?(_value), do: false
-
-  defp default_actions do
-    [
-      %{
-        id: "export",
-        label: "Export",
-        icon: @export_icon_svg,
-        quick_action: true,
-        requires_confirmation: false
-      },
-      %{
-        id: "delete",
-        label: "Delete",
-        icon: @delete_icon_svg,
-        icon_class: "text-red-500",
-        text_class: "text-red-700",
-        quick_action: true,
-        requires_confirmation: true,
-        confirmation_message:
-          "This will permanently delete the selected items. This action cannot be undone."
-      },
-      %{
-        divider: true,
-        id: "archive",
-        label: "Archive",
-        description: "Move to archive",
-        requires_confirmation: true
-      },
-      %{
-        id: "duplicate",
-        label: "Duplicate",
-        requires_confirmation: false
-      },
-      %{
-        id: "merge",
-        label: "Merge",
-        badge: "Beta",
-        requires_confirmation: true
-      }
-    ]
-  end
 
   defp action_button_class(action, selection_count) do
     base = "transition-colors"

--- a/lib/selecto_components/enhanced_table/bulk_actions.ex
+++ b/lib/selecto_components/enhanced_table/bulk_actions.ex
@@ -395,7 +395,6 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
   end
 
   def handle_event("cancel_processing", _params, socket) do
-    send(self(), :cancel_bulk_processing)
     {:noreply, assign(socket, processing: false)}
   end
 
@@ -520,88 +519,57 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
         total_to_process: length(selected_ids),
         errors: []
       )
-      |> start_batch_processing(action, selected_ids)
+      |> process_selected_batches(action, selected_ids)
     else
       socket
     end
   end
 
-  defp start_batch_processing(socket, action, selected_ids) do
+  defp process_selected_batches(socket, action, selected_ids) do
     batch_size = action[:batch_size] || 10
     batches = Enum.chunk_every(selected_ids, batch_size)
 
-    # Send first batch for processing
-    send(self(), {:process_batch, action, batches, 0})
-
-    socket
-  end
-
-  def handle_info({:process_batch, action, batches, index}, socket) do
-    if index < length(batches) do
-      batch = Enum.at(batches, index)
-
-      # Process batch
+    Enum.reduce_while(batches, socket, fn batch, batch_socket ->
       case process_batch(action, batch) do
         {:ok, _results} ->
-          new_count = socket.assigns.processed_count + length(batch)
-
-          socket = assign(socket, processed_count: new_count)
-
-          # Schedule next batch
-          if index + 1 < length(batches) do
-            Process.send_after(self(), {:process_batch, action, batches, index + 1}, 100)
-          else
-            # All done
-            send(self(), :bulk_processing_complete)
-          end
-
-          {:noreply, socket}
+          {:cont,
+           assign(batch_socket,
+             processed_count: batch_socket.assigns.processed_count + length(batch)
+           )}
 
         {:error, errors} ->
-          {:noreply,
-           socket
-           |> assign(errors: socket.assigns.errors ++ errors)
+          {:halt,
+           batch_socket
+           |> assign(errors: batch_socket.assigns.errors ++ List.wrap(errors))
            |> assign(processing: false)}
       end
-    else
-      {:noreply, socket}
-    end
-  end
-
-  def handle_info(:bulk_processing_complete, socket) do
-    send(self(), {:bulk_action_complete, socket.assigns.bulk_action})
-
-    {:noreply,
-     socket
-     |> assign(processing: false)
-     |> RowSelection.clear_selection()}
-  end
-
-  def handle_info(:cancel_bulk_processing, socket) do
-    {:noreply, assign(socket, processing: false)}
+    end)
+    |> finish_batch_processing()
   end
 
   # Helper functions
 
+  defp finish_batch_processing(%{assigns: %{processing: false}} = socket), do: socket
+
+  defp finish_batch_processing(socket) do
+    socket
+    |> assign(processing: false)
+    |> RowSelection.clear_selection()
+  end
+
   defp process_batch(action, batch_ids) do
-    # Call the configured action handler if available, otherwise return success
     case action do
       %{handler: handler} when is_function(handler, 1) ->
-        # Call custom handler function
         handler.(batch_ids)
 
       %{handler: {module, function}} when is_atom(module) and is_atom(function) ->
-        # Call module function
         apply(module, function, [batch_ids])
 
       %{id: action_id} ->
-        # Send to parent process for handling
-        send(self(), {:bulk_action_process_batch, action_id, batch_ids})
-        # Return success - actual processing happens in parent
-        {:ok, batch_ids}
+        {:error, ["No handler configured for bulk action #{action_id}."]}
 
       _ ->
-        {:ok, batch_ids}
+        {:error, ["No handler configured for this bulk action."]}
     end
   end
 

--- a/lib/selecto_components/enhanced_table/bulk_actions.ex
+++ b/lib/selecto_components/enhanced_table/bulk_actions.ex
@@ -3,9 +3,7 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
   Bulk actions interface for performing operations on multiple selected records.
 
   Bulk actions should come from domain action contracts and render as generated
-  `ActionFormModal` entries. Passing explicit `:actions` is a deprecated
-  pre-1.0 compatibility path kept only while the remaining callers move to
-  domain actions; do not add new behavior there.
+  `ActionFormModal` entries.
   """
 
   use Phoenix.LiveComponent
@@ -13,33 +11,16 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
   alias SelectoComponents.EnhancedTable.RowSelection
   alias Phoenix.LiveView.JS
 
-  @export_icon_svg ~s(<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path></svg>)
-
-  @delete_icon_svg ~s(<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>)
-
-  @trusted_icons MapSet.new([@export_icon_svg, @delete_icon_svg])
-
   @impl true
   def mount(socket) do
-    {:ok,
-     socket
-     |> RowSelection.init_selection()
-     |> assign(
-       bulk_action: nil,
-       processing: false,
-       processed_count: 0,
-       total_to_process: 0,
-       errors: [],
-       show_confirmation: false,
-       confirmation_message: nil
-     )}
+    {:ok, RowSelection.init_selection(socket)}
   end
 
   @impl true
   def update(assigns, socket) do
     actions =
-      (assigns[:actions] || [])
-      |> Kernel.++(generated_action_forms(assigns))
+      assigns
+      |> generated_action_forms()
       |> Enum.map(&normalize_action_item/1)
       |> Enum.reject(&is_nil/1)
 
@@ -56,7 +37,7 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
     assigns = assign(assigns, menu_id: "#{assigns.id}-menu")
 
     ~H"""
-    <div id={@id} class="bulk-actions-container" phx-hook=".BulkActions" data-selected-count={@selection_count}>
+    <div id={@id} class="bulk-actions-container" data-selected-count={@selection_count}>
       <%!-- Bulk Actions Toolbar --%>
       <div class="flex items-center justify-between px-4 py-2 bg-gray-50 border-b">
         <div class="flex items-center space-x-4">
@@ -121,212 +102,8 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
           </div>
         </div>
 
-        <%!-- Quick Actions --%>
-        <div class="flex items-center space-x-2">
-          <%= for action <- Enum.filter(@actions, & &1.quick_action) do %>
-            <button
-              type="button"
-              class={"px-3 py-1.5 text-sm rounded-lg flex items-center space-x-1 #{action_button_class(action, @selection_count)}"}
-              disabled={@selection_count == 0 || @processing}
-              phx-click="execute_action"
-              phx-value-action={action.id}
-              phx-target={@myself}
-            >
-              <%= if icon = safe_icon(action.icon) do %>
-                {icon}
-              <% end %>
-              <span>{action.label}</span>
-            </button>
-          <% end %>
-        </div>
+        <div></div>
       </div>
-
-      <%!-- Progress Bar --%>
-      <%= if @processing do %>
-        <div class="px-4 py-2 bg-blue-50 border-b border-blue-200">
-          <div class="flex items-center justify-between mb-2">
-            <span class="text-sm font-medium text-blue-900">
-              Processing {@processed_count} of {@total_to_process} items...
-            </span>
-            <button
-              type="button"
-              class="text-sm text-blue-600 hover:text-blue-800"
-              phx-click="cancel_processing"
-              phx-target={@myself}
-            >
-              Cancel
-            </button>
-          </div>
-          <div class="w-full bg-blue-200 rounded-full h-2">
-            <div
-              class="bg-blue-600 h-2 rounded-full transition-all duration-300"
-              style={"width: #{progress_percentage(@processed_count, @total_to_process)}%"}
-            >
-            </div>
-          </div>
-        </div>
-      <% end %>
-
-      <%!-- Error Display --%>
-      <%= if length(@errors) > 0 do %>
-        <div class="px-4 py-2 bg-red-50 border-b border-red-200">
-          <div class="flex items-start">
-            <svg
-              class="w-5 h-5 text-red-600 mr-2 flex-shrink-0"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-                clip-rule="evenodd"
-              />
-            </svg>
-            <div class="flex-1">
-              <p class="text-sm font-medium text-red-900">
-                {length(@errors)} {if length(@errors) == 1, do: "error", else: "errors"} occurred
-              </p>
-              <ul class="mt-1 text-sm text-red-700">
-                <%= for error <- Enum.take(@errors, 3) do %>
-                  <li>• {error}</li>
-                <% end %>
-                <%= if length(@errors) > 3 do %>
-                  <li class="text-red-600">...and {length(@errors) - 3} more</li>
-                <% end %>
-              </ul>
-            </div>
-            <button
-              type="button"
-              class="text-red-600 hover:text-red-800"
-              phx-click="dismiss_errors"
-              phx-target={@myself}
-            >
-              <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                <path
-                  fill-rule="evenodd"
-                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                  clip-rule="evenodd"
-                />
-              </svg>
-            </button>
-          </div>
-        </div>
-      <% end %>
-
-      <%!-- Confirmation Dialog --%>
-      <%= if @show_confirmation do %>
-        <div
-          id="confirmation-dialog"
-          class="fixed inset-0 z-50 overflow-y-auto"
-          phx-hook=".ConfirmationDialog"
-        >
-          <div class="flex items-center justify-center min-h-screen px-4">
-            <div
-              class="fixed inset-0 bg-gray-500 bg-opacity-75"
-              phx-click="cancel_action"
-              phx-target={@myself}
-            >
-            </div>
-
-            <div class="relative bg-white rounded-lg shadow-xl max-w-md w-full">
-              <div class="px-6 py-4">
-                <div class="flex items-start">
-                  <div class="flex-shrink-0">
-                    <svg
-                      class="w-6 h-6 text-yellow-600"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-                      />
-                    </svg>
-                  </div>
-                  <div class="ml-3 flex-1">
-                    <h3 class="text-lg font-medium text-gray-900">Confirm Bulk Action</h3>
-                    <p class="mt-2 text-sm text-gray-500">
-                      {@confirmation_message}
-                    </p>
-                    <p class="mt-2 text-sm font-medium text-gray-700">
-                      This will affect {@selection_count} {if @selection_count == 1,
-                        do: "item",
-                        else: "items"}.
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              <div class="px-6 py-4 bg-gray-50 flex justify-end space-x-2">
-                <button
-                  type="button"
-                  class="px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-100"
-                  phx-click="cancel_action"
-                  phx-target={@myself}
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  class="px-4 py-2 bg-red-600 text-white rounded-lg text-sm font-medium hover:bg-red-700"
-                  phx-click="confirm_action"
-                  phx-target={@myself}
-                >
-                  Confirm
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      <% end %>
-
-      <script :type={Phoenix.LiveView.ColocatedHook} name=".BulkActions">
-        export default {
-          mounted() {
-            this.handleKeydown = (event) => {
-              if (event.key === 'Delete' && !event.target.matches('input, textarea')) {
-                const selectedCount = parseInt(this.el.dataset.selectedCount || '0', 10);
-                if (selectedCount > 0) {
-                  event.preventDefault();
-                  this.pushEventTo(this.el, 'execute_action', {action: 'delete'});
-                }
-              }
-            };
-
-            document.addEventListener('keydown', this.handleKeydown);
-          },
-
-          destroyed() {
-            document.removeEventListener('keydown', this.handleKeydown);
-          }
-        };
-      </script>
-
-      <script :type={Phoenix.LiveView.ColocatedHook} name=".ConfirmationDialog">
-        export default {
-          mounted() {
-            const confirmBtn = this.el.querySelector('button[phx-click="confirm_action"]');
-            if (confirmBtn) {
-              confirmBtn.focus();
-            }
-
-            this.handleKeydown = (event) => {
-              if (event.key === 'Escape') {
-                this.pushEventTo(this.el, 'cancel_action', {});
-              }
-            };
-
-            document.addEventListener('keydown', this.handleKeydown);
-          },
-
-          destroyed() {
-            document.removeEventListener('keydown', this.handleKeydown);
-          }
-        };
-      </script>
     </div>
     """
   end
@@ -344,17 +121,7 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
         data-bulk-action-source={Map.get(@action, :source)}
         data-bulk-action-scope={Map.get(@action, :scope)}
       >
-        <%= if icon = safe_icon(@action.icon) do %>
-          <span class={@action.icon_class || "text-gray-500"}>
-            {icon}
-          </span>
-        <% end %>
-        <span class={@action.text_class || "text-gray-700"}>{@action.label}</span>
-        <%= if @action.badge do %>
-          <span class="ml-auto px-2 py-0.5 text-xs bg-gray-200 rounded-full">
-            {@action.badge}
-          </span>
-        <% end %>
+        <span class="text-gray-700">{@action.label}</span>
       </button>
       <%= if @action.description do %>
         <p class="px-4 pb-2 text-xs text-gray-500">{@action.description}</p>
@@ -369,42 +136,11 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
   def handle_event("execute_action", %{"action" => action_id}, socket) do
     action = Enum.find(socket.assigns.actions, &(&1.id == action_id))
 
-    cond do
-      generated_action_form?(action) ->
-        {:noreply, open_generated_action_form(socket, action)}
-
-      action && action.requires_confirmation ->
-        {:noreply,
-         socket
-         |> assign(
-           show_confirmation: true,
-           confirmation_message:
-             action.confirmation_message || "Are you sure you want to perform this action?",
-           bulk_action: action
-         )}
-
-      true ->
-        {:noreply, execute_bulk_action(socket, action)}
+    if generated_action_form?(action) do
+      {:noreply, open_generated_action_form(socket, action)}
+    else
+      {:noreply, socket}
     end
-  end
-
-  def handle_event("confirm_action", _params, socket) do
-    {:noreply,
-     socket
-     |> assign(show_confirmation: false)
-     |> execute_bulk_action(socket.assigns.bulk_action)}
-  end
-
-  def handle_event("cancel_action", _params, socket) do
-    {:noreply, assign(socket, show_confirmation: false, bulk_action: nil)}
-  end
-
-  def handle_event("cancel_processing", _params, socket) do
-    {:noreply, assign(socket, processing: false)}
-  end
-
-  def handle_event("dismiss_errors", _params, socket) do
-    {:noreply, assign(socket, errors: [])}
   end
 
   def handle_event("toggle_row_selection", %{"id" => row_id}, socket) do
@@ -509,80 +245,6 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
 
   defp resolve_selection_value(value, _selection_context), do: value
 
-  # Deprecated explicit-action execution path.
-  #
-  # Domain actions should render generated action-form menu items and run through
-  # `ActionFormModal` + `ActionFormHost`. Keep this small and removable; it is
-  # only present to keep explicit `actions:` assigns parent-safe until it is
-  # deleted before 1.0.
-
-  defp execute_bulk_action(socket, nil), do: socket
-
-  defp execute_bulk_action(socket, action) do
-    selected_ids = RowSelection.get_selected_ids(socket)
-
-    if length(selected_ids) > 0 do
-      socket
-      |> assign(
-        processing: true,
-        processed_count: 0,
-        total_to_process: length(selected_ids),
-        errors: []
-      )
-      |> process_selected_batches(action, selected_ids)
-    else
-      socket
-    end
-  end
-
-  defp process_selected_batches(socket, action, selected_ids) do
-    batch_size = action[:batch_size] || 10
-    batches = Enum.chunk_every(selected_ids, batch_size)
-
-    Enum.reduce_while(batches, socket, fn batch, batch_socket ->
-      case process_batch(action, batch) do
-        {:ok, _results} ->
-          {:cont,
-           assign(batch_socket,
-             processed_count: batch_socket.assigns.processed_count + length(batch)
-           )}
-
-        {:error, errors} ->
-          {:halt,
-           batch_socket
-           |> assign(errors: batch_socket.assigns.errors ++ List.wrap(errors))
-           |> assign(processing: false)}
-      end
-    end)
-    |> finish_batch_processing()
-  end
-
-  # Helper functions
-
-  defp finish_batch_processing(%{assigns: %{processing: false}} = socket), do: socket
-
-  defp finish_batch_processing(socket) do
-    socket
-    |> assign(processing: false)
-    |> RowSelection.clear_selection()
-  end
-
-  defp process_batch(action, batch_ids) do
-    case action do
-      %{handler: handler} when is_function(handler, 1) ->
-        handler.(batch_ids)
-
-      %{handler: {module, function}} when is_atom(module) and is_atom(function) ->
-        apply(module, function, [batch_ids])
-
-      %{id: action_id} ->
-        {:error, ["No handler configured for bulk action #{action_id}."]}
-
-      _ ->
-        {:error, ["No handler configured for this bulk action."]}
-    end
-  end
-
   defp get_all_row_ids(socket) do
     # Get row IDs from various possible sources
     cond do
@@ -686,16 +348,6 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
     Phoenix.LiveView.send_update(__MODULE__, id: component_id, all_row_ids: row_ids)
   end
 
-  defp safe_icon(icon) when is_binary(icon) do
-    if MapSet.member?(@trusted_icons, icon) do
-      Phoenix.HTML.raw(icon)
-    else
-      nil
-    end
-  end
-
-  defp safe_icon(_icon), do: nil
-
   defp generated_action_forms(assigns) do
     assigns
     |> generated_action_contract()
@@ -726,8 +378,6 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
       scope: "bulk",
       type: :live_component,
       payload: payload,
-      quick_action: false,
-      requires_confirmation: false,
       confirmation_message: map_value(action, :confirmation_message)
     }
   end
@@ -739,20 +389,12 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
       id: map_value(action, :id),
       label: map_value(action, :label),
       description: map_value(action, :description),
-      icon: map_value(action, :icon),
-      icon_class: map_value(action, :icon_class),
-      text_class: map_value(action, :text_class),
-      badge: map_value(action, :badge),
       divider: truthy?(map_value(action, :divider)),
-      quick_action: truthy?(map_value(action, :quick_action)),
-      requires_confirmation: truthy?(map_value(action, :requires_confirmation)),
       confirmation_message: map_value(action, :confirmation_message),
-      source: map_value(action, :source) || :deprecated_explicit_bulk_action,
+      source: map_value(action, :source),
       scope: map_value(action, :scope),
       type: map_value(action, :type),
-      payload: map_value(action, :payload, %{}),
-      batch_size: map_value(action, :batch_size),
-      handler: map_value(action, :handler)
+      payload: map_value(action, :payload, %{})
     }
   end
 
@@ -770,32 +412,6 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
 
   defp truthy?(value) when value in [true, "true", "1", 1, :yes], do: true
   defp truthy?(_value), do: false
-
-  defp action_button_class(action, selection_count) do
-    base = "transition-colors"
-
-    disabled =
-      if selection_count == 0 do
-        "opacity-50 cursor-not-allowed"
-      else
-        ""
-      end
-
-    color =
-      case action.id do
-        "delete" -> "bg-red-100 text-red-700 hover:bg-red-200"
-        "export" -> "bg-green-100 text-green-700 hover:bg-green-200"
-        _ -> "bg-gray-100 text-gray-700 hover:bg-gray-200"
-      end
-
-    "#{base} #{color} #{disabled}"
-  end
-
-  defp progress_percentage(0, 0), do: 0
-
-  defp progress_percentage(processed, total) do
-    round(processed / total * 100)
-  end
 
   defp toggle_actions_menu(menu_id) do
     JS.toggle(

--- a/lib/selecto_components/enhanced_table/bulk_actions.ex
+++ b/lib/selecto_components/enhanced_table/bulk_actions.ex
@@ -39,7 +39,7 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
     ~H"""
     <div id={@id} class="bulk-actions-container" data-selected-count={@selection_count}>
       <%!-- Bulk Actions Toolbar --%>
-      <div class="flex items-center justify-between px-4 py-2 bg-gray-50 border-b">
+      <div class="flex items-center px-4 py-2 bg-gray-50 border-b">
         <div class="flex items-center space-x-4">
           <%!-- Selection Info --%>
           <%= if @selection_count > 0 do %>
@@ -102,7 +102,6 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
           </div>
         </div>
 
-        <div></div>
       </div>
     </div>
     """

--- a/lib/selecto_components/enhanced_table/bulk_actions.ex
+++ b/lib/selecto_components/enhanced_table/bulk_actions.ex
@@ -48,6 +48,8 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
 
   @impl true
   def render(assigns) do
+    assigns = assign(assigns, menu_id: "#{assigns.id}-menu")
+
     ~H"""
     <div id={@id} class="bulk-actions-container" phx-hook=".BulkActions" data-selected-count={@selection_count}>
       <%!-- Bulk Actions Toolbar --%>
@@ -63,7 +65,7 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
                 type="button"
                 class="text-sm text-blue-600 hover:text-blue-800"
                 phx-click="clear_selection"
-                phx-target={@myself}
+                phx-target={assigns[:selection_target] || @myself}
               >
                 Clear
               </button>
@@ -76,7 +78,7 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
               type="button"
               class={"px-4 py-2 bg-white border rounded-lg flex items-center space-x-2 #{if @selection_count == 0, do: "opacity-50 cursor-not-allowed", else: "hover:bg-gray-50"}"}
               disabled={@selection_count == 0}
-              phx-click={toggle_actions_menu()}
+              phx-click={toggle_actions_menu(@menu_id)}
             >
               <svg class="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path
@@ -98,11 +100,17 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
             </button>
 
             <div
-              id="bulk-actions-menu"
+              id={@menu_id}
               class="hidden absolute left-0 mt-2 w-56 bg-white rounded-lg shadow-lg border border-gray-200 z-20"
             >
-              <%= for action <- @actions do %>
-                {render_action_item(assigns, action)}
+              <%= if @actions == [] do %>
+                <div class="px-4 py-3 text-sm text-gray-500" data-bulk-actions-empty>
+                  No bulk actions available
+                </div>
+              <% else %>
+                <%= for action <- @actions do %>
+                  {render_action_item(assigns, action)}
+                <% end %>
               <% end %>
             </div>
           </div>
@@ -326,9 +334,7 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
       <button
         type="button"
         class="w-full text-left px-4 py-2 text-sm hover:bg-gray-100 flex items-center space-x-2"
-        phx-click="execute_action"
-        phx-value-action={@action.id}
-        phx-target={@myself}
+        phx-click={execute_action_click(@menu_id, @action.id, @myself)}
         data-bulk-action-id={@action.id}
         data-bulk-action-source={Map.get(@action, :source)}
         data-bulk-action-scope={Map.get(@action, :scope)}
@@ -854,11 +860,16 @@ defmodule SelectoComponents.EnhancedTable.BulkActions do
     round(processed / total * 100)
   end
 
-  defp toggle_actions_menu do
+  defp toggle_actions_menu(menu_id) do
     JS.toggle(
-      to: "#bulk-actions-menu",
+      to: "##{menu_id}",
       in: {"ease-out duration-100", "opacity-0 scale-95", "opacity-100 scale-100"},
       out: {"ease-in duration-75", "opacity-100 scale-100", "opacity-0 scale-95"}
     )
+  end
+
+  defp execute_action_click(menu_id, action_id, target) do
+    JS.hide(to: "##{menu_id}")
+    |> JS.push("execute_action", value: %{action: action_id}, target: target)
   end
 end

--- a/lib/selecto_components/enhanced_table/row_selection.ex
+++ b/lib/selecto_components/enhanced_table/row_selection.ex
@@ -332,7 +332,10 @@ defmodule SelectoComponents.EnhancedTable.RowSelection do
   # Private functions
 
   defp broadcast_selection_change(socket) do
-    send(self(), {:selection_changed, socket.assigns.selected_rows})
+    if Map.get(socket.assigns, :notify_selection_change, false) do
+      send(self(), {:selection_changed, socket.assigns.selected_rows})
+    end
+
     socket
   end
 

--- a/lib/selecto_components/form.ex
+++ b/lib/selecto_components/form.ex
@@ -1987,7 +1987,10 @@ defmodule SelectoComponents.Form do
   defp detail_modal_visible?(assigns) do
     Map.get(assigns, :show_detail_modal) &&
       (Map.get(assigns, :enable_modal_detail, false) ||
-         Map.get(Map.get(assigns, :modal_detail_data, %{}), :action_source) == :configured)
+         Map.get(Map.get(assigns, :modal_detail_data, %{}), :action_source) in [
+           :configured,
+           :generated_action_form
+         ])
   end
 
   defp scheduled_export_context(assigns) do

--- a/lib/selecto_components/form.ex
+++ b/lib/selecto_components/form.ex
@@ -1989,7 +1989,8 @@ defmodule SelectoComponents.Form do
       (Map.get(assigns, :enable_modal_detail, false) ||
          Map.get(Map.get(assigns, :modal_detail_data, %{}), :action_source) in [
            :configured,
-           :generated_action_form
+           :generated_action_form,
+           :generated_bulk_action_form
          ])
   end
 

--- a/lib/selecto_components/form/event_handlers/modal_operations.ex
+++ b/lib/selecto_components/form/event_handlers/modal_operations.ex
@@ -47,6 +47,8 @@ defmodule SelectoComponents.Form.EventHandlers.ModalOperations do
       """
       @impl true
       def handle_info({:show_detail_modal, detail_data}, socket) do
+        detail_data = prepare_detail_modal_data(detail_data, socket)
+
         # Check if modal detail view is enabled (opt-in feature)
         if detail_modal_enabled?(socket.assigns, detail_data) do
           # Set modal data in assigns to trigger rendering
@@ -90,6 +92,14 @@ defmodule SelectoComponents.Form.EventHandlers.ModalOperations do
       defp detail_modal_enabled?(assigns, detail_data) do
         Map.get(assigns, :enable_modal_detail, false) ||
           Map.get(detail_data || %{}, :action_source) == :configured
+      end
+
+      defp prepare_detail_modal_data(detail_data, socket) do
+        if function_exported?(__MODULE__, :prepare_selecto_detail_modal_data, 2) do
+          apply(__MODULE__, :prepare_selecto_detail_modal_data, [detail_data, socket])
+        else
+          detail_data
+        end
       end
     end
   end

--- a/lib/selecto_components/form/event_handlers/modal_operations.ex
+++ b/lib/selecto_components/form/event_handlers/modal_operations.ex
@@ -91,7 +91,11 @@ defmodule SelectoComponents.Form.EventHandlers.ModalOperations do
 
       defp detail_modal_enabled?(assigns, detail_data) do
         Map.get(assigns, :enable_modal_detail, false) ||
-          Map.get(detail_data || %{}, :action_source) in [:configured, :generated_action_form]
+          Map.get(detail_data || %{}, :action_source) in [
+            :configured,
+            :generated_action_form,
+            :generated_bulk_action_form
+          ]
       end
 
       defp prepare_detail_modal_data(detail_data, socket) do

--- a/lib/selecto_components/form/event_handlers/modal_operations.ex
+++ b/lib/selecto_components/form/event_handlers/modal_operations.ex
@@ -91,7 +91,7 @@ defmodule SelectoComponents.Form.EventHandlers.ModalOperations do
 
       defp detail_modal_enabled?(assigns, detail_data) do
         Map.get(assigns, :enable_modal_detail, false) ||
-          Map.get(detail_data || %{}, :action_source) == :configured
+          Map.get(detail_data || %{}, :action_source) in [:configured, :generated_action_form]
       end
 
       defp prepare_detail_modal_data(detail_data, socket) do

--- a/lib/selecto_components/modal/action_form_modal.ex
+++ b/lib/selecto_components/modal/action_form_modal.ex
@@ -196,7 +196,10 @@ defmodule SelectoComponents.Modal.ActionFormModal do
               <dd class="mt-1 font-mono text-xs text-emerald-950">{item.value}</dd>
             </div>
           </dl>
-          <pre class="max-h-56 overflow-auto"><%= Jason.encode!(@last_result, pretty: true) %></pre>
+          <details data-selecto-action-form-result-details class="mt-2">
+            <summary class="cursor-pointer font-medium text-emerald-800">Response details</summary>
+            <pre class="mt-2 max-h-56 overflow-auto rounded bg-white/70 p-2 text-emerald-950 ring-1 ring-emerald-100"><%= Jason.encode!(@last_result, pretty: true) %></pre>
+          </details>
         </div>
 
         <div :if={@applied?} data-selecto-action-form-applied class="rounded border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
@@ -557,14 +560,20 @@ defmodule SelectoComponents.Modal.ActionFormModal do
         "Changes",
         first_present([map_value(payload, "changes"), get_in(payload, ["preview", "changes"])])
       ),
-      summary_item(
-        "record",
-        "Record",
+      record_summary_item(
         first_present([get_in(payload, ["result", "record"]), map_value(payload, "record")])
       )
     ]
     |> Enum.reject(&is_nil/1)
   end
+
+  defp record_summary_item(nil), do: nil
+
+  defp record_summary_item(records) when is_list(records) do
+    summary_item("records", "Records", "#{length(records)} records")
+  end
+
+  defp record_summary_item(record), do: summary_item("record", "Record", record)
 
   defp result_payload(result) when is_map(result) do
     map_value(result, "payload", result)

--- a/lib/selecto_components/modal/action_form_modal.ex
+++ b/lib/selecto_components/modal/action_form_modal.ex
@@ -62,6 +62,7 @@ defmodule SelectoComponents.Modal.ActionFormModal do
       |> assign_new(:last_result, fn -> nil end)
       |> assign_new(:last_error, fn -> nil end)
       |> assign_new(:submitting, fn -> nil end)
+      |> assign(:applied?, applied_result?(Map.get(assigns, :last_result)))
 
     ~H"""
     <div data-selecto-action-form-modal class="space-y-4">
@@ -134,13 +135,17 @@ defmodule SelectoComponents.Modal.ActionFormModal do
           <pre class="max-h-56 overflow-auto"><%= Jason.encode!(@last_result, pretty: true) %></pre>
         </div>
 
+        <div :if={@applied?} data-selecto-action-form-applied class="rounded border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
+          This action has been applied. Reopen the row to run another action request.
+        </div>
+
         <div class="flex justify-end gap-2">
           <button
             type="submit"
             name="intent"
             value="preview"
             class="rounded bg-indigo-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={@submitting == "preview"}
+            disabled={@applied? || @submitting == "preview"}
           >
             Preview
           </button>
@@ -149,7 +154,7 @@ defmodule SelectoComponents.Modal.ActionFormModal do
             name="intent"
             value="apply"
             class="rounded bg-emerald-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={apply_disabled?(@confirmation, @confirmed, @submitting)}
+            disabled={apply_disabled?(@confirmation, @confirmed, @submitting, @applied?)}
           >
             Apply
           </button>
@@ -294,9 +299,14 @@ defmodule SelectoComponents.Modal.ActionFormModal do
   defp truthy?(value) when value in [true, "true", "1", 1, :yes], do: true
   defp truthy?(_value), do: false
 
-  defp apply_disabled?(confirmation, confirmed, submitting) do
-    submitting == "apply" or (truthy?(Map.get(confirmation, "required")) and not confirmed)
+  defp apply_disabled?(confirmation, confirmed, submitting, applied?) do
+    applied? or submitting == "apply" or
+      (truthy?(Map.get(confirmation, "required")) and not confirmed)
   end
+
+  defp applied_result?(%{"intent" => "apply"}), do: true
+  defp applied_result?(%{intent: "apply"}), do: true
+  defp applied_result?(_result), do: false
 
   defp result_title(%{"intent" => "apply"}), do: "Apply result"
   defp result_title(%{intent: "apply"}), do: "Apply result"

--- a/lib/selecto_components/modal/action_form_modal.ex
+++ b/lib/selecto_components/modal/action_form_modal.ex
@@ -63,6 +63,8 @@ defmodule SelectoComponents.Modal.ActionFormModal do
       |> assign_new(:last_error, fn -> nil end)
       |> assign_new(:submitting, fn -> nil end)
       |> assign(:applied?, applied_result?(Map.get(assigns, :last_result)))
+      |> assign(:disabled?, disabled_action?(action))
+      |> assign(:disabled_reason, disabled_reason(action))
 
     ~H"""
     <div data-selecto-action-form-modal class="space-y-4">
@@ -130,6 +132,10 @@ defmodule SelectoComponents.Modal.ActionFormModal do
           {@last_error}
         </div>
 
+        <div :if={@disabled?} data-selecto-action-form-disabled class="rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+          {@disabled_reason || "This action is not available for the selected target."}
+        </div>
+
         <div :if={@last_result} data-selecto-action-form-result class="rounded border border-emerald-200 bg-emerald-50 p-3 text-xs text-emerald-900">
           <div class="mb-1 font-semibold">{result_title(@last_result)}</div>
           <pre class="max-h-56 overflow-auto"><%= Jason.encode!(@last_result, pretty: true) %></pre>
@@ -145,7 +151,7 @@ defmodule SelectoComponents.Modal.ActionFormModal do
             name="intent"
             value="preview"
             class="rounded bg-indigo-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={@applied? || @submitting == "preview"}
+            disabled={@disabled? || @applied? || @submitting == "preview"}
           >
             Preview
           </button>
@@ -154,7 +160,7 @@ defmodule SelectoComponents.Modal.ActionFormModal do
             name="intent"
             value="apply"
             class="rounded bg-emerald-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={apply_disabled?(@confirmation, @confirmed, @submitting, @applied?)}
+            disabled={apply_disabled?(@confirmation, @confirmed, @submitting, @applied?, @disabled?)}
           >
             Apply
           </button>
@@ -299,9 +305,17 @@ defmodule SelectoComponents.Modal.ActionFormModal do
   defp truthy?(value) when value in [true, "true", "1", 1, :yes], do: true
   defp truthy?(_value), do: false
 
-  defp apply_disabled?(confirmation, confirmed, submitting, applied?) do
-    applied? or submitting == "apply" or
+  defp apply_disabled?(confirmation, confirmed, submitting, applied?, disabled?) do
+    disabled? or applied? or submitting == "apply" or
       (truthy?(Map.get(confirmation, "required")) and not confirmed)
+  end
+
+  defp disabled_action?(action) do
+    Map.get(action, "disabled?") == true or Map.get(action, "status") == "disabled"
+  end
+
+  defp disabled_reason(action) do
+    Map.get(action, "reason") || Map.get(action, "disabled_reason")
   end
 
   defp applied_result?(%{"intent" => "apply"}), do: true

--- a/lib/selecto_components/modal/action_form_modal.ex
+++ b/lib/selecto_components/modal/action_form_modal.ex
@@ -65,6 +65,7 @@ defmodule SelectoComponents.Modal.ActionFormModal do
       |> assign(:applied?, applied_result?(Map.get(assigns, :last_result)))
       |> assign(:disabled?, disabled_action?(action))
       |> assign(:disabled_reason, disabled_reason(action))
+      |> assign(:result_summary, result_summary(Map.get(assigns, :last_result)))
 
     ~H"""
     <div data-selecto-action-form-modal class="space-y-4">
@@ -160,6 +161,12 @@ defmodule SelectoComponents.Modal.ActionFormModal do
 
         <div :if={@last_result} data-selecto-action-form-result class="rounded border border-emerald-200 bg-emerald-50 p-3 text-xs text-emerald-900">
           <div class="mb-1 font-semibold">{result_title(@last_result)}</div>
+          <dl :if={@result_summary != []} data-selecto-action-form-result-summary class="mb-3 grid gap-2 text-sm sm:grid-cols-2">
+            <div :for={item <- @result_summary} data-selecto-action-form-result-summary-item={item.key} class="rounded bg-white/70 p-2 ring-1 ring-emerald-100">
+              <dt class="text-[11px] font-semibold uppercase text-emerald-700">{item.label}</dt>
+              <dd class="mt-1 font-mono text-xs text-emerald-950">{item.value}</dd>
+            </div>
+          </dl>
           <pre class="max-h-56 overflow-auto"><%= Jason.encode!(@last_result, pretty: true) %></pre>
         </div>
 
@@ -469,4 +476,65 @@ defmodule SelectoComponents.Modal.ActionFormModal do
   defp result_title(%{"intent" => "apply"}), do: "Apply result"
   defp result_title(%{intent: "apply"}), do: "Apply result"
   defp result_title(_result), do: "Preview result"
+
+  defp result_summary(nil), do: []
+
+  defp result_summary(result) do
+    payload = result_payload(result)
+
+    [
+      summary_item(
+        "action",
+        "Action",
+        first_present([map_value(payload, "action"), get_in(payload, ["preview", "action"])])
+      ),
+      summary_item(
+        "mode",
+        "Mode",
+        first_present([get_in(payload, ["result", "mode"]), map_value(payload, "mode")])
+      ),
+      summary_item(
+        "changes",
+        "Changes",
+        first_present([map_value(payload, "changes"), get_in(payload, ["preview", "changes"])])
+      ),
+      summary_item(
+        "record",
+        "Record",
+        first_present([get_in(payload, ["result", "record"]), map_value(payload, "record")])
+      )
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp result_payload(result) when is_map(result) do
+    map_value(result, "payload", result)
+  end
+
+  defp result_payload(_result), do: %{}
+
+  defp summary_item(_key, _label, nil), do: nil
+
+  defp summary_item(key, label, value) do
+    %{key: key, label: label, value: summary_value(value)}
+  end
+
+  defp summary_value(value) when is_map(value) or is_list(value), do: Jason.encode!(value)
+  defp summary_value(value), do: to_string(value)
+
+  defp first_present(values), do: Enum.find(values, &(not is_nil(&1)))
+
+  defp map_value(map, key, default \\ nil)
+
+  defp map_value(map, key, default) when is_map(map) and is_binary(key),
+    do: Map.get(map, key, Map.get(map, safe_existing_atom(key), default))
+
+  defp map_value(map, key, default) when is_map(map), do: Map.get(map, key, default)
+  defp map_value(_map, _key, default), do: default
+
+  defp safe_existing_atom(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> nil
+  end
 end

--- a/lib/selecto_components/modal/action_form_modal.ex
+++ b/lib/selecto_components/modal/action_form_modal.ex
@@ -1,0 +1,146 @@
+defmodule SelectoComponents.Modal.ActionFormModal do
+  @moduledoc """
+  Modal component for rendering a domain action as a form shell.
+
+  Host applications still own action preview/apply execution. This component
+  renders the action metadata, target row, request template, inputs, and
+  confirmation affordance so Selecto result rows can open action forms through
+  the existing detail-action modal path.
+  """
+
+  use Phoenix.LiveComponent
+  alias SelectoComponents.Actions
+
+  @impl true
+  def mount(socket) do
+    {:ok,
+     assign(socket,
+       action: %{},
+       target: %{},
+       record: %{}
+     )}
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    {:ok, assign(socket, assigns)}
+  end
+
+  @impl true
+  def render(assigns) do
+    action = normalize_action(Map.get(assigns, :action, %{}))
+    target = normalize_target(assigns)
+    request_template = Actions.request_template(action, target: target)
+
+    assigns =
+      assigns
+      |> assign(:action, action)
+      |> assign(:target, target)
+      |> assign(:request_template, request_template)
+      |> assign(:inputs, Map.get(action, :inputs, Map.get(action, "inputs", [])))
+      |> assign(
+        :confirmation,
+        Map.get(action, :confirmation, Map.get(action, "confirmation", %{}))
+      )
+
+    ~H"""
+    <div data-selecto-action-form-modal class="space-y-4">
+      <div class="rounded border border-slate-200 bg-slate-50 p-3 text-sm">
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="font-semibold text-slate-900">{Map.get(@action, :id) || Map.get(@action, "id")}</span>
+          <span :if={Map.get(@action, :operation) || Map.get(@action, "operation")} class="rounded bg-white px-2 py-0.5 text-xs text-slate-600 ring-1 ring-slate-200">
+            {Map.get(@action, :operation) || Map.get(@action, "operation")}
+          </span>
+          <span :if={Map.get(@action, :scope) || Map.get(@action, "scope")} class="rounded bg-white px-2 py-0.5 text-xs text-slate-600 ring-1 ring-slate-200">
+            {Map.get(@action, :scope) || Map.get(@action, "scope")}
+          </span>
+        </div>
+        <p :if={Map.get(@action, :capability) || Map.get(@action, "capability")} class="mt-1 font-mono text-xs text-slate-500">
+          {Map.get(@action, :capability) || Map.get(@action, "capability")}
+        </p>
+      </div>
+
+      <div data-selecto-action-form-target class="rounded border border-slate-200 p-3">
+        <h4 class="text-sm font-semibold text-slate-900">Target</h4>
+        <dl class="mt-2 grid gap-2 text-sm sm:grid-cols-2">
+          <div :for={{key, value} <- @target}>
+            <dt class="text-xs uppercase text-slate-500">{key}</dt>
+            <dd class="font-medium text-slate-800">{inspect(value)}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div data-selecto-action-form-inputs class="space-y-3">
+        <h4 class="text-sm font-semibold text-slate-900">Inputs</h4>
+        <p :if={@inputs == []} class="text-sm text-slate-500">This action has no additional inputs.</p>
+        <label :for={input <- @inputs} class="block">
+          <span class="text-sm font-medium text-slate-700">
+            {Map.get(input, "label") || humanize(Map.get(input, "id"))}
+            <span :if={truthy?(Map.get(input, "required"))} class="text-rose-600">*</span>
+          </span>
+          <input
+            name={"inputs[#{Map.get(input, "id")}]"}
+            value={Map.get(@request_template["inputs"] || %{}, Map.get(input, "id"), "")}
+            type={input_type(input)}
+            class="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+          />
+        </label>
+      </div>
+
+      <label :if={truthy?(Map.get(@confirmation, "required"))} class="flex items-start gap-2 rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+        <input type="checkbox" name="confirmed" value="true" class="mt-0.5" />
+        <span>{Map.get(@confirmation, "message") || "Confirm this action before applying."}</span>
+      </label>
+
+      <details class="text-xs text-slate-600">
+        <summary class="cursor-pointer font-medium text-slate-700">Request template</summary>
+        <pre class="mt-2 max-h-48 overflow-auto rounded bg-slate-950 p-3 text-slate-100"><%= Jason.encode!(@request_template, pretty: true) %></pre>
+      </details>
+
+      <div class="flex justify-end gap-2">
+        <button type="button" class="rounded bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-70" disabled>
+          Preview
+        </button>
+        <button type="button" class="rounded bg-emerald-600 px-3 py-2 text-sm font-medium text-white opacity-70" disabled>
+          Apply
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  defp normalize_action(action) when is_map(action),
+    do: SelectoComponents.QueryContract.json_safe(action)
+
+  defp normalize_action(_action), do: %{}
+
+  defp normalize_target(assigns) do
+    explicit = Map.get(assigns, :target, %{})
+    record = Map.get(assigns, :record, %{})
+
+    (explicit || %{})
+    |> Map.new(fn {key, value} -> {to_string(key), value} end)
+    |> Map.put_new("id", Map.get(record, "id", Map.get(record, :id)))
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  defp input_type(%{"type" => "boolean"}), do: "checkbox"
+
+  defp input_type(%{"type" => type}) when type in ["integer", "number", "float", "decimal"],
+    do: "number"
+
+  defp input_type(_input), do: "text"
+
+  defp humanize(nil), do: "Input"
+
+  defp humanize(value) do
+    value
+    |> to_string()
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+
+  defp truthy?(value) when value in [true, "true", "1", 1, :yes], do: true
+  defp truthy?(_value), do: false
+end

--- a/lib/selecto_components/modal/action_form_modal.ex
+++ b/lib/selecto_components/modal/action_form_modal.ex
@@ -81,6 +81,8 @@ defmodule SelectoComponents.Modal.ActionFormModal do
       data-action-operation={Map.get(@action, :operation) || Map.get(@action, "operation")}
       data-action-scope={Map.get(@action, :scope) || Map.get(@action, "scope")}
       data-action-status={@action_status}
+      data-action-submitting={@submitting}
+      aria-busy={not is_nil(@submitting)}
       class="space-y-4"
     >
       <div class="rounded border border-slate-200 bg-slate-50 p-3 text-sm">
@@ -203,6 +205,16 @@ defmodule SelectoComponents.Modal.ActionFormModal do
 
         <div class="flex justify-end gap-2">
           <button
+            :if={(@last_result || @last_error) && !@applied?}
+            type="button"
+            phx-click="reset_action_form"
+            phx-target={@myself}
+            data-selecto-action-form-reset
+            class="rounded border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Clear result
+          </button>
+          <button
             type="submit"
             name="intent"
             value="preview"
@@ -236,6 +248,20 @@ defmodule SelectoComponents.Modal.ActionFormModal do
        confirmed: truthy?(Map.get(params, "confirmed")),
        last_error: nil
      )}
+  end
+
+  def handle_event("reset_action_form", _params, socket) do
+    if applied_result?(Map.get(socket.assigns, :last_result)) do
+      {:noreply, socket}
+    else
+      {:noreply,
+       assign(socket,
+         submitting: nil,
+         last_request: nil,
+         last_result: nil,
+         last_error: nil
+       )}
+    end
   end
 
   def handle_event("submit_action_form", params, socket) do

--- a/lib/selecto_components/modal/action_form_modal.ex
+++ b/lib/selecto_components/modal/action_form_modal.ex
@@ -111,6 +111,8 @@ defmodule SelectoComponents.Modal.ActionFormModal do
             <select
               :if={select_input?(input)}
               name={"inputs[#{Map.get(input, "id")}]"}
+              required={required_html_input?(input)}
+              aria-required={input_required?(input)}
               class="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
             >
               <option :for={option <- input_options(input)} value={option_value(option)} selected={option_selected?(option, input, @form_inputs)}>
@@ -121,6 +123,8 @@ defmodule SelectoComponents.Modal.ActionFormModal do
               :if={textarea_input?(input)}
               name={"inputs[#{Map.get(input, "id")}]"}
               rows={input_rows(input)}
+              required={required_html_input?(input)}
+              aria-required={input_required?(input)}
               class="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
             ><%= Map.get(@form_inputs, Map.get(input, "id"), "") %></textarea>
             <input
@@ -129,6 +133,8 @@ defmodule SelectoComponents.Modal.ActionFormModal do
               value={Map.get(@form_inputs, Map.get(input, "id"), "")}
               type={input_type(input)}
               checked={input_checked?(input, @form_inputs)}
+              required={required_html_input?(input)}
+              aria-required={input_required?(input)}
               class={input_class(input)}
             />
           </label>
@@ -191,7 +197,8 @@ defmodule SelectoComponents.Modal.ActionFormModal do
     {:noreply,
      assign(socket,
        form_inputs: Map.get(params, "inputs", %{}),
-       confirmed: truthy?(Map.get(params, "confirmed"))
+       confirmed: truthy?(Map.get(params, "confirmed")),
+       last_error: nil
      )}
   end
 
@@ -205,6 +212,22 @@ defmodule SelectoComponents.Modal.ActionFormModal do
 
     confirmed = truthy?(Map.get(params, "confirmed"))
 
+    case validate_required_inputs(inputs, Map.get(socket.assigns, :inputs, [])) do
+      :ok ->
+        submit_action_request(socket, action, target, intent, inputs, confirmed)
+
+      {:error, message} ->
+        {:noreply,
+         assign(socket,
+           form_inputs: inputs,
+           confirmed: confirmed,
+           submitting: nil,
+           last_error: message
+         )}
+    end
+  end
+
+  defp submit_action_request(socket, action, target, intent, inputs, confirmed) do
     request =
       Actions.request_template(action,
         target: target,
@@ -323,6 +346,10 @@ defmodule SelectoComponents.Modal.ActionFormModal do
   defp input_class(_input),
     do: "mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
 
+  defp required_html_input?(input), do: input_required?(input) and input_type(input) != "checkbox"
+
+  defp input_required?(input), do: truthy?(Map.get(input, "required"))
+
   defp select_input?(input), do: input_options(input) != []
 
   defp textarea_input?(input) do
@@ -384,6 +411,31 @@ defmodule SelectoComponents.Modal.ActionFormModal do
   end
 
   defp input_checked?(_input, _form_inputs), do: false
+
+  defp validate_required_inputs(inputs, input_defs) do
+    missing =
+      input_defs
+      |> List.wrap()
+      |> Enum.filter(&input_required?/1)
+      |> Enum.filter(fn input ->
+        inputs
+        |> Map.get(Map.get(input, "id"))
+        |> blank_input_value?()
+      end)
+      |> Enum.map(&input_label/1)
+
+    case missing do
+      [] -> :ok
+      labels -> {:error, "Required inputs missing: #{Enum.join(labels, ", ")}."}
+    end
+  end
+
+  defp blank_input_value?(value) when value in [nil, ""], do: true
+  defp blank_input_value?(value) when is_binary(value), do: String.trim(value) == ""
+  defp blank_input_value?(value) when is_list(value), do: value == []
+  defp blank_input_value?(_value), do: false
+
+  defp input_label(input), do: Map.get(input, "label") || humanize(Map.get(input, "id"))
 
   defp humanize(nil), do: "Input"
 

--- a/lib/selecto_components/modal/action_form_modal.ex
+++ b/lib/selecto_components/modal/action_form_modal.ex
@@ -156,6 +156,9 @@ defmodule SelectoComponents.Modal.ActionFormModal do
               value={Map.get(@form_inputs, Map.get(input, "id"), "")}
               type={input_type(input)}
               checked={input_checked?(input, @form_inputs)}
+              min={input_attr(input, "min")}
+              max={input_attr(input, "max")}
+              step={input_attr(input, "step")}
               required={required_html_input?(input)}
               aria-required={input_required?(input)}
               disabled={@controls_disabled?}
@@ -401,6 +404,8 @@ defmodule SelectoComponents.Modal.ActionFormModal do
 
   defp input_class(_input),
     do: "mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+
+  defp input_attr(input, key), do: Map.get(input, key) || get_in(input, ["raw", key])
 
   defp required_html_input?(input), do: input_required?(input) and input_type(input) != "checkbox"
 

--- a/lib/selecto_components/modal/action_form_modal.ex
+++ b/lib/selecto_components/modal/action_form_modal.ex
@@ -66,6 +66,7 @@ defmodule SelectoComponents.Modal.ActionFormModal do
       |> assign_new(:last_result, fn -> nil end)
       |> assign_new(:last_error, fn -> nil end)
       |> assign_new(:submitting, fn -> nil end)
+      |> assign_new(:show_debug_json?, fn -> false end)
       |> assign(:applied?, applied?)
       |> assign(:disabled?, disabled?)
       |> assign(:controls_disabled?, controls_disabled?)
@@ -175,7 +176,7 @@ defmodule SelectoComponents.Modal.ActionFormModal do
           <span>{Map.get(@confirmation, "message") || "Confirm this action before applying."}</span>
         </label>
 
-        <details class="text-xs text-slate-600">
+        <details :if={@show_debug_json?} class="text-xs text-slate-600">
           <summary class="cursor-pointer font-medium text-slate-700">Request template</summary>
           <pre class="mt-2 max-h-48 overflow-auto rounded bg-slate-950 p-3 text-slate-100"><%= Jason.encode!(@request_template, pretty: true) %></pre>
         </details>
@@ -196,7 +197,7 @@ defmodule SelectoComponents.Modal.ActionFormModal do
               <dd class="mt-1 font-mono text-xs text-emerald-950">{item.value}</dd>
             </div>
           </dl>
-          <details data-selecto-action-form-result-details class="mt-2">
+          <details :if={@show_debug_json?} data-selecto-action-form-result-details class="mt-2">
             <summary class="cursor-pointer font-medium text-emerald-800">Response details</summary>
             <pre class="mt-2 max-h-56 overflow-auto rounded bg-white/70 p-2 text-emerald-950 ring-1 ring-emerald-100"><%= Jason.encode!(@last_result, pretty: true) %></pre>
           </details>
@@ -304,10 +305,6 @@ defmodule SelectoComponents.Modal.ActionFormModal do
     payload = %{
       intent: intent,
       action_id: Map.get(action, "id"),
-      action: action,
-      target: target,
-      record: socket.assigns.record,
-      endpoint: endpoint_for(action, intent),
       request: request
     }
 
@@ -385,12 +382,6 @@ defmodule SelectoComponents.Modal.ActionFormModal do
   defp normalize_input_value(value, %{"type" => "boolean"}), do: truthy?(value)
   defp normalize_input_value(nil, input), do: Map.get(input, "default", "")
   defp normalize_input_value(value, _input), do: value
-
-  defp endpoint_for(action, intent) do
-    action
-    |> Map.get("endpoints", %{})
-    |> Map.get(intent, %{})
-  end
 
   defp input_type(%{"type" => "boolean"}), do: "checkbox"
 

--- a/lib/selecto_components/modal/action_form_modal.ex
+++ b/lib/selecto_components/modal/action_form_modal.ex
@@ -17,7 +17,13 @@ defmodule SelectoComponents.Modal.ActionFormModal do
      assign(socket,
        action: %{},
        target: %{},
-       record: %{}
+       record: %{},
+       form_inputs: %{},
+       confirmed: false,
+       submitting: nil,
+       last_request: nil,
+       last_result: nil,
+       last_error: nil
      )}
   end
 
@@ -30,18 +36,32 @@ defmodule SelectoComponents.Modal.ActionFormModal do
   def render(assigns) do
     action = normalize_action(Map.get(assigns, :action, %{}))
     target = normalize_target(assigns)
-    request_template = Actions.request_template(action, target: target)
+    inputs = Map.get(action, :inputs, Map.get(action, "inputs", []))
+    form_inputs = Map.get(assigns, :form_inputs, %{})
+    request_inputs = form_inputs |> merge_default_inputs(action) |> normalize_inputs(inputs)
+
+    request_template =
+      Actions.request_template(action,
+        target: target,
+        inputs: request_inputs,
+        confirmed: truthy?(Map.get(assigns, :confirmed))
+      )
 
     assigns =
       assigns
       |> assign(:action, action)
       |> assign(:target, target)
       |> assign(:request_template, request_template)
-      |> assign(:inputs, Map.get(action, :inputs, Map.get(action, "inputs", [])))
+      |> assign(:inputs, inputs)
+      |> assign(:form_inputs, request_inputs)
       |> assign(
         :confirmation,
         Map.get(action, :confirmation, Map.get(action, "confirmation", %{}))
       )
+      |> assign(:confirmed, truthy?(Map.get(assigns, :confirmed)))
+      |> assign_new(:last_result, fn -> nil end)
+      |> assign_new(:last_error, fn -> nil end)
+      |> assign_new(:submitting, fn -> nil end)
 
     ~H"""
     <div data-selecto-action-form-modal class="space-y-4">
@@ -70,49 +90,131 @@ defmodule SelectoComponents.Modal.ActionFormModal do
         </dl>
       </div>
 
-      <div data-selecto-action-form-inputs class="space-y-3">
-        <h4 class="text-sm font-semibold text-slate-900">Inputs</h4>
-        <p :if={@inputs == []} class="text-sm text-slate-500">This action has no additional inputs.</p>
-        <label :for={input <- @inputs} class="block">
-          <span class="text-sm font-medium text-slate-700">
-            {Map.get(input, "label") || humanize(Map.get(input, "id"))}
-            <span :if={truthy?(Map.get(input, "required"))} class="text-rose-600">*</span>
-          </span>
-          <input
-            name={"inputs[#{Map.get(input, "id")}]"}
-            value={Map.get(@request_template["inputs"] || %{}, Map.get(input, "id"), "")}
-            type={input_type(input)}
-            class="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
-          />
+      <form
+        id={"#{@id}-form"}
+        phx-change="change_action_form"
+        phx-submit="submit_action_form"
+        phx-target={@myself}
+        class="space-y-4"
+      >
+        <div data-selecto-action-form-inputs class="space-y-3">
+          <h4 class="text-sm font-semibold text-slate-900">Inputs</h4>
+          <p :if={@inputs == []} class="text-sm text-slate-500">This action has no additional inputs.</p>
+          <label :for={input <- @inputs} class="block">
+            <span class="text-sm font-medium text-slate-700">
+              {Map.get(input, "label") || humanize(Map.get(input, "id"))}
+              <span :if={truthy?(Map.get(input, "required"))} class="text-rose-600">*</span>
+            </span>
+            <input
+              name={"inputs[#{Map.get(input, "id")}]"}
+              value={Map.get(@form_inputs, Map.get(input, "id"), "")}
+              type={input_type(input)}
+              checked={input_checked?(input, @form_inputs)}
+              class="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+            />
+          </label>
+        </div>
+
+        <label :if={truthy?(Map.get(@confirmation, "required"))} class="flex items-start gap-2 rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+          <input type="checkbox" name="confirmed" value="true" checked={@confirmed} class="mt-0.5" />
+          <span>{Map.get(@confirmation, "message") || "Confirm this action before applying."}</span>
         </label>
-      </div>
 
-      <label :if={truthy?(Map.get(@confirmation, "required"))} class="flex items-start gap-2 rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
-        <input type="checkbox" name="confirmed" value="true" class="mt-0.5" />
-        <span>{Map.get(@confirmation, "message") || "Confirm this action before applying."}</span>
-      </label>
+        <details class="text-xs text-slate-600">
+          <summary class="cursor-pointer font-medium text-slate-700">Request template</summary>
+          <pre class="mt-2 max-h-48 overflow-auto rounded bg-slate-950 p-3 text-slate-100"><%= Jason.encode!(@request_template, pretty: true) %></pre>
+        </details>
 
-      <details class="text-xs text-slate-600">
-        <summary class="cursor-pointer font-medium text-slate-700">Request template</summary>
-        <pre class="mt-2 max-h-48 overflow-auto rounded bg-slate-950 p-3 text-slate-100"><%= Jason.encode!(@request_template, pretty: true) %></pre>
-      </details>
+        <div :if={@last_error} data-selecto-action-form-error class="rounded border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800">
+          {@last_error}
+        </div>
 
-      <div class="flex justify-end gap-2">
-        <button type="button" class="rounded bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-70" disabled>
-          Preview
-        </button>
-        <button type="button" class="rounded bg-emerald-600 px-3 py-2 text-sm font-medium text-white opacity-70" disabled>
-          Apply
-        </button>
-      </div>
+        <div :if={@last_result} data-selecto-action-form-result class="rounded border border-emerald-200 bg-emerald-50 p-3 text-xs text-emerald-900">
+          <div class="mb-1 font-semibold">{result_title(@last_result)}</div>
+          <pre class="max-h-56 overflow-auto"><%= Jason.encode!(@last_result, pretty: true) %></pre>
+        </div>
+
+        <div class="flex justify-end gap-2">
+          <button
+            type="submit"
+            name="intent"
+            value="preview"
+            class="rounded bg-indigo-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={@submitting == "preview"}
+          >
+            Preview
+          </button>
+          <button
+            type="submit"
+            name="intent"
+            value="apply"
+            class="rounded bg-emerald-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={apply_disabled?(@confirmation, @confirmed, @submitting)}
+          >
+            Apply
+          </button>
+        </div>
+      </form>
     </div>
     """
+  end
+
+  @impl true
+  def handle_event("change_action_form", params, socket) do
+    {:noreply,
+     assign(socket,
+       form_inputs: Map.get(params, "inputs", %{}),
+       confirmed: truthy?(Map.get(params, "confirmed"))
+     )}
+  end
+
+  def handle_event("submit_action_form", params, socket) do
+    intent = normalize_intent(Map.get(params, "intent"))
+    action = normalize_action(socket.assigns.action)
+    target = normalize_target(socket.assigns)
+
+    inputs =
+      params |> Map.get("inputs", %{}) |> normalize_inputs(Map.get(socket.assigns, :inputs, []))
+
+    confirmed = truthy?(Map.get(params, "confirmed"))
+
+    request =
+      Actions.request_template(action,
+        target: target,
+        inputs: inputs,
+        dry_run: intent == "preview",
+        confirmed: confirmed
+      )
+
+    payload = %{
+      intent: intent,
+      action_id: Map.get(action, "id"),
+      action: action,
+      target: target,
+      record: socket.assigns.record,
+      endpoint: endpoint_for(action, intent),
+      request: request
+    }
+
+    send(self(), {:selecto_action_form_submit, payload})
+
+    {:noreply,
+     assign(socket,
+       form_inputs: inputs,
+       confirmed: confirmed,
+       submitting: intent,
+       last_request: request,
+       last_error: nil
+     )}
   end
 
   defp normalize_action(action) when is_map(action),
     do: SelectoComponents.QueryContract.json_safe(action)
 
   defp normalize_action(_action), do: %{}
+
+  defp normalize_intent("apply"), do: "apply"
+  defp normalize_intent(_intent), do: "preview"
 
   defp normalize_target(assigns) do
     explicit = Map.get(assigns, :target, %{})
@@ -125,12 +227,60 @@ defmodule SelectoComponents.Modal.ActionFormModal do
     |> Map.new()
   end
 
+  defp merge_default_inputs(inputs, action) when is_map(inputs) do
+    action
+    |> Actions.request_template()
+    |> Map.get("inputs", %{})
+    |> Map.merge(inputs)
+  end
+
+  defp merge_default_inputs(_inputs, action) do
+    action
+    |> Actions.request_template()
+    |> Map.get("inputs", %{})
+  end
+
+  defp normalize_inputs(inputs, input_defs) when is_map(inputs) do
+    input_defs
+    |> List.wrap()
+    |> Map.new(fn input ->
+      id = Map.get(input, "id")
+      {id, normalize_input_value(Map.get(inputs, id), input)}
+    end)
+    |> Map.merge(Map.drop(inputs, [nil]))
+    |> Enum.reject(fn {key, _value} -> is_nil(key) end)
+    |> Map.new()
+  end
+
+  defp normalize_inputs(_inputs, _input_defs), do: %{}
+
+  defp normalize_input_value(nil, %{"type" => "boolean"}), do: false
+  defp normalize_input_value("true", %{"type" => "boolean"}), do: true
+  defp normalize_input_value("false", %{"type" => "boolean"}), do: false
+  defp normalize_input_value(value, %{"type" => "boolean"}), do: truthy?(value)
+  defp normalize_input_value(nil, input), do: Map.get(input, "default", "")
+  defp normalize_input_value(value, _input), do: value
+
+  defp endpoint_for(action, intent) do
+    action
+    |> Map.get("endpoints", %{})
+    |> Map.get(intent, %{})
+  end
+
   defp input_type(%{"type" => "boolean"}), do: "checkbox"
 
   defp input_type(%{"type" => type}) when type in ["integer", "number", "float", "decimal"],
     do: "number"
 
   defp input_type(_input), do: "text"
+
+  defp input_checked?(%{"type" => "boolean"} = input, form_inputs) do
+    form_inputs
+    |> Map.get(Map.get(input, "id"))
+    |> truthy?()
+  end
+
+  defp input_checked?(_input, _form_inputs), do: false
 
   defp humanize(nil), do: "Input"
 
@@ -143,4 +293,12 @@ defmodule SelectoComponents.Modal.ActionFormModal do
 
   defp truthy?(value) when value in [true, "true", "1", 1, :yes], do: true
   defp truthy?(_value), do: false
+
+  defp apply_disabled?(confirmation, confirmed, submitting) do
+    submitting == "apply" or (truthy?(Map.get(confirmation, "required")) and not confirmed)
+  end
+
+  defp result_title(%{"intent" => "apply"}), do: "Apply result"
+  defp result_title(%{intent: "apply"}), do: "Apply result"
+  defp result_title(_result), do: "Preview result"
 end

--- a/lib/selecto_components/modal/action_form_modal.ex
+++ b/lib/selecto_components/modal/action_form_modal.ex
@@ -108,12 +108,28 @@ defmodule SelectoComponents.Modal.ActionFormModal do
               {Map.get(input, "label") || humanize(Map.get(input, "id"))}
               <span :if={truthy?(Map.get(input, "required"))} class="text-rose-600">*</span>
             </span>
+            <select
+              :if={select_input?(input)}
+              name={"inputs[#{Map.get(input, "id")}]"}
+              class="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+            >
+              <option :for={option <- input_options(input)} value={option_value(option)} selected={option_selected?(option, input, @form_inputs)}>
+                {option_label(option)}
+              </option>
+            </select>
+            <textarea
+              :if={textarea_input?(input)}
+              name={"inputs[#{Map.get(input, "id")}]"}
+              rows={input_rows(input)}
+              class="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+            ><%= Map.get(@form_inputs, Map.get(input, "id"), "") %></textarea>
             <input
+              :if={!select_input?(input) && !textarea_input?(input)}
               name={"inputs[#{Map.get(input, "id")}]"}
               value={Map.get(@form_inputs, Map.get(input, "id"), "")}
               type={input_type(input)}
               checked={input_checked?(input, @form_inputs)}
-              class="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+              class={input_class(input)}
             />
           </label>
         </div>
@@ -252,13 +268,23 @@ defmodule SelectoComponents.Modal.ActionFormModal do
   end
 
   defp normalize_inputs(inputs, input_defs) when is_map(inputs) do
-    input_defs
-    |> List.wrap()
-    |> Map.new(fn input ->
-      id = Map.get(input, "id")
-      {id, normalize_input_value(Map.get(inputs, id), input)}
-    end)
-    |> Map.merge(Map.drop(inputs, [nil]))
+    input_defs = List.wrap(input_defs)
+
+    normalized_defined =
+      Map.new(input_defs, fn input ->
+        id = Map.get(input, "id")
+        {id, normalize_input_value(Map.get(inputs, id), input)}
+      end)
+
+    defined_ids =
+      input_defs
+      |> Enum.map(&Map.get(&1, "id"))
+      |> MapSet.new()
+
+    inputs
+    |> Enum.reject(fn {key, _value} -> is_nil(key) or MapSet.member?(defined_ids, key) end)
+    |> Map.new()
+    |> Map.merge(normalized_defined)
     |> Enum.reject(fn {key, _value} -> is_nil(key) end)
     |> Map.new()
   end
@@ -283,7 +309,73 @@ defmodule SelectoComponents.Modal.ActionFormModal do
   defp input_type(%{"type" => type}) when type in ["integer", "number", "float", "decimal"],
     do: "number"
 
+  defp input_type(%{"type" => type}) when type in ["email", "url", "date", "time"],
+    do: type
+
+  defp input_type(%{"type" => type}) when type in ["datetime", "datetime-local"],
+    do: "datetime-local"
+
   defp input_type(_input), do: "text"
+
+  defp input_class(%{"type" => "boolean"}),
+    do: "mt-1 rounded border border-slate-300 text-sm"
+
+  defp input_class(_input),
+    do: "mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+
+  defp select_input?(input), do: input_options(input) != []
+
+  defp textarea_input?(input) do
+    input
+    |> Map.get("type")
+    |> to_string()
+    |> Kernel.in(["text", "textarea", "long_text"])
+  end
+
+  defp input_options(input) do
+    input
+    |> input_option_source()
+    |> List.wrap()
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp input_option_source(input) do
+    Map.get(input, "options") ||
+      Map.get(input, "choices") ||
+      Map.get(input, "values") ||
+      input
+      |> Map.get("raw", %{})
+      |> then(fn raw ->
+        Map.get(raw, "options") || Map.get(raw, "choices") || Map.get(raw, "values") || []
+      end)
+  end
+
+  defp input_rows(input) do
+    Map.get(input, "rows") || get_in(input, ["raw", "rows"]) || 4
+  end
+
+  defp option_selected?(option, input, form_inputs) do
+    current_value =
+      form_inputs
+      |> Map.get(Map.get(input, "id"), Map.get(input, "default", ""))
+      |> to_string()
+
+    option_value(option) == current_value
+  end
+
+  defp option_value(%{"value" => value}), do: to_string(value)
+  defp option_value(%{value: value}), do: to_string(value)
+  defp option_value(%{"id" => value}), do: to_string(value)
+  defp option_value(%{id: value}), do: to_string(value)
+  defp option_value({value, _label}), do: to_string(value)
+  defp option_value(value), do: to_string(value)
+
+  defp option_label(%{"label" => label}), do: label
+  defp option_label(%{label: label}), do: label
+  defp option_label(%{"name" => label}), do: label
+  defp option_label(%{name: label}), do: label
+  defp option_label({_value, label}), do: label
+  defp option_label(value), do: humanize(value)
 
   defp input_checked?(%{"type" => "boolean"} = input, form_inputs) do
     form_inputs

--- a/lib/selecto_components/modal/action_form_modal.ex
+++ b/lib/selecto_components/modal/action_form_modal.ex
@@ -47,6 +47,10 @@ defmodule SelectoComponents.Modal.ActionFormModal do
         confirmed: truthy?(Map.get(assigns, :confirmed))
       )
 
+    applied? = applied_result?(Map.get(assigns, :last_result))
+    disabled? = disabled_action?(action)
+    controls_disabled? = disabled? || applied?
+
     assigns =
       assigns
       |> assign(:action, action)
@@ -62,13 +66,23 @@ defmodule SelectoComponents.Modal.ActionFormModal do
       |> assign_new(:last_result, fn -> nil end)
       |> assign_new(:last_error, fn -> nil end)
       |> assign_new(:submitting, fn -> nil end)
-      |> assign(:applied?, applied_result?(Map.get(assigns, :last_result)))
-      |> assign(:disabled?, disabled_action?(action))
+      |> assign(:applied?, applied?)
+      |> assign(:disabled?, disabled?)
+      |> assign(:controls_disabled?, controls_disabled?)
       |> assign(:disabled_reason, disabled_reason(action))
+      |> assign(:action_status, action_status(disabled?, applied?))
       |> assign(:result_summary, result_summary(Map.get(assigns, :last_result)))
 
     ~H"""
-    <div data-selecto-action-form-modal class="space-y-4">
+    <div
+      data-selecto-action-form-modal
+      data-action-id={Map.get(@action, :id) || Map.get(@action, "id")}
+      data-action-capability={Map.get(@action, :capability) || Map.get(@action, "capability")}
+      data-action-operation={Map.get(@action, :operation) || Map.get(@action, "operation")}
+      data-action-scope={Map.get(@action, :scope) || Map.get(@action, "scope")}
+      data-action-status={@action_status}
+      class="space-y-4"
+    >
       <div class="rounded border border-slate-200 bg-slate-50 p-3 text-sm">
         <div class="flex flex-wrap items-center gap-2">
           <span class="font-semibold text-slate-900">{Map.get(@action, :id) || Map.get(@action, "id")}</span>
@@ -111,9 +125,11 @@ defmodule SelectoComponents.Modal.ActionFormModal do
             </span>
             <select
               :if={select_input?(input)}
+              data-selecto-action-form-input={Map.get(input, "id")}
               name={"inputs[#{Map.get(input, "id")}]"}
               required={required_html_input?(input)}
               aria-required={input_required?(input)}
+              disabled={@controls_disabled?}
               class="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
             >
               <option :for={option <- input_options(input)} value={option_value(option)} selected={option_selected?(option, input, @form_inputs)}>
@@ -122,27 +138,38 @@ defmodule SelectoComponents.Modal.ActionFormModal do
             </select>
             <textarea
               :if={textarea_input?(input)}
+              data-selecto-action-form-input={Map.get(input, "id")}
               name={"inputs[#{Map.get(input, "id")}]"}
               rows={input_rows(input)}
               required={required_html_input?(input)}
               aria-required={input_required?(input)}
+              disabled={@controls_disabled?}
               class="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
             ><%= Map.get(@form_inputs, Map.get(input, "id"), "") %></textarea>
             <input
               :if={!select_input?(input) && !textarea_input?(input)}
+              data-selecto-action-form-input={Map.get(input, "id")}
               name={"inputs[#{Map.get(input, "id")}]"}
               value={Map.get(@form_inputs, Map.get(input, "id"), "")}
               type={input_type(input)}
               checked={input_checked?(input, @form_inputs)}
               required={required_html_input?(input)}
               aria-required={input_required?(input)}
+              disabled={@controls_disabled?}
               class={input_class(input)}
             />
           </label>
         </div>
 
         <label :if={truthy?(Map.get(@confirmation, "required"))} class="flex items-start gap-2 rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
-          <input type="checkbox" name="confirmed" value="true" checked={@confirmed} class="mt-0.5" />
+          <input
+            type="checkbox"
+            name="confirmed"
+            value="true"
+            checked={@confirmed}
+            disabled={@controls_disabled?}
+            class="mt-0.5"
+          />
           <span>{Map.get(@confirmation, "message") || "Confirm this action before applying."}</span>
         </label>
 
@@ -179,6 +206,7 @@ defmodule SelectoComponents.Modal.ActionFormModal do
             type="submit"
             name="intent"
             value="preview"
+            data-selecto-action-form-submit="preview"
             class="rounded bg-indigo-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
             disabled={@disabled? || @applied? || @submitting == "preview"}
           >
@@ -188,6 +216,7 @@ defmodule SelectoComponents.Modal.ActionFormModal do
             type="submit"
             name="intent"
             value="apply"
+            data-selecto-action-form-submit="apply"
             class="rounded bg-emerald-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
             disabled={apply_disabled?(@confirmation, @confirmed, @submitting, @applied?, @disabled?)}
           >
@@ -464,6 +493,10 @@ defmodule SelectoComponents.Modal.ActionFormModal do
   defp disabled_action?(action) do
     Map.get(action, "disabled?") == true or Map.get(action, "status") == "disabled"
   end
+
+  defp action_status(_disabled?, true), do: "applied"
+  defp action_status(true, _applied?), do: "disabled"
+  defp action_status(_disabled?, _applied?), do: "enabled"
 
   defp disabled_reason(action) do
     Map.get(action, "reason") || Map.get(action, "disabled_reason")

--- a/lib/selecto_components/query_contract.ex
+++ b/lib/selecto_components/query_contract.ex
@@ -337,6 +337,11 @@ defmodule SelectoComponents.QueryContract do
 
   @doc false
   @spec json_safe(term()) :: term()
+  def json_safe(%DateTime{} = value), do: DateTime.to_iso8601(value)
+  def json_safe(%NaiveDateTime{} = value), do: NaiveDateTime.to_iso8601(value)
+  def json_safe(%Date{} = value), do: Date.to_iso8601(value)
+  def json_safe(%Time{} = value), do: Time.to_iso8601(value)
+
   def json_safe(value) when is_map(value) do
     Enum.reduce(value, %{}, fn {key, value}, acc ->
       case json_safe(value) do

--- a/lib/selecto_components/views/detail/component.ex
+++ b/lib/selecto_components/views/detail/component.ex
@@ -6,6 +6,8 @@ defmodule SelectoComponents.Views.Detail.Component do
   import SelectoComponents.Components.SqlDebug
   alias SelectoComponents.Env
   alias SelectoComponents.ErrorHandling.ErrorBuilder
+  alias SelectoComponents.EnhancedTable.BulkActions
+  alias SelectoComponents.EnhancedTable.RowSelection
   alias SelectoComponents.EnhancedTable.Sorting
   alias SelectoComponents.Presentation
   alias SelectoComponents.Theme
@@ -19,6 +21,7 @@ defmodule SelectoComponents.Views.Detail.Component do
 
     socket =
       socket
+      |> RowSelection.init_selection()
       |> assign(:columns_config, init_columns_config(columns))
 
     {:ok, socket}
@@ -153,6 +156,39 @@ defmodule SelectoComponents.Views.Detail.Component do
       end
 
     total_pages = if total_rows > 0, do: max_page + 1, else: 0
+    {_query_results, columns_from_query, aliases_from_query} = assigns.query_results
+
+    row_action_query_columns =
+      Map.get(
+        assigns.selecto.set,
+        :row_action_query_columns,
+        Map.get(assigns.selecto.set, :columns, [])
+      )
+
+    visible_row_ids =
+      normalized_results
+      |> Enum.with_index(row_offset)
+      |> Enum.map(fn {row, absolute_idx} ->
+        row_values = normalize_row_values(row, columns_from_query, aliases_from_query)
+
+        row
+        |> build_row_action_context(
+          row_values,
+          row_action_query_columns,
+          columns_from_query,
+          aliases_from_query
+        )
+        |> row_selection_id(absolute_idx)
+      end)
+
+    visible_row_id_set = MapSet.new(visible_row_ids)
+
+    selected_rows =
+      assigns
+      |> Map.get(:selected_rows, MapSet.new())
+      |> MapSet.intersection(visible_row_id_set)
+
+    selection_count = MapSet.size(selected_rows)
 
     ### Use Selecto columns rather than aliases because a column can lead to more than one selection...
 
@@ -168,12 +204,16 @@ defmodule SelectoComponents.Views.Detail.Component do
         page_end: page_end,
         total_pages: total_pages,
         columns: Map.get(assigns.selecto.set, :columns, []),
-        row_action_query_columns:
-          Map.get(
-            assigns.selecto.set,
-            :row_action_query_columns,
-            Map.get(assigns.selecto.set, :columns, [])
-          ),
+        row_action_query_columns: row_action_query_columns,
+        query_columns: columns_from_query,
+        query_aliases: aliases_from_query,
+        visible_row_ids: visible_row_ids,
+        selected_rows: selected_rows,
+        selection_count: selection_count,
+        select_all: selection_count > 0 and selection_count == length(visible_row_ids),
+        visible_selection_count: selection_count,
+        bulk_actions_component_id:
+          "detail-bulk-actions-#{Map.get(assigns, :id, "detail-component")}",
         column_uuids:
           Map.get(assigns.selecto.set, :columns, []) |> Enum.map(fn c -> c["uuid"] end),
         max_page: max_page
@@ -322,6 +362,18 @@ defmodule SelectoComponents.Views.Detail.Component do
         </div>
       </div>
 
+      <.live_component
+        module={BulkActions}
+        id={@bulk_actions_component_id}
+        selecto={@selecto}
+        actions={[]}
+        selected_rows={@selected_rows}
+        selection_count={@selection_count}
+        selection_target={@myself}
+        total_rows={length(@visible_row_ids)}
+        all_row_ids={@visible_row_ids}
+      />
+
       <div
         class={Theme.slot(@theme, :panel) <> " responsive-table-wrapper overflow-x-auto"}
         id={"detail-table-wrapper-#{@myself}"}
@@ -330,6 +382,12 @@ defmodule SelectoComponents.Views.Detail.Component do
         <table class="min-w-full table-auto">
           <thead style="background: var(--sc-surface-bg-alt);">
             <tr>
+              <RowSelection.selection_header
+                target={@myself}
+                select_all={@select_all}
+                selection_count={@visible_selection_count}
+                total_rows={length(@visible_row_ids)}
+              />
               <th class="w-12 max-w-12 min-w-12 px-2 py-3 text-center text-xs font-medium uppercase tracking-wider" style="background: var(--sc-surface-bg-alt); color: var(--sc-text-secondary); border-bottom: 1px solid var(--sc-surface-border);">
                 #
               </th>
@@ -372,12 +430,10 @@ defmodule SelectoComponents.Views.Detail.Component do
                     # If it's already a map, extract values in column order.
                     # Fall back to alias at the same position to avoid collisions
                     # from duplicate DB column names.
-                    {_results, columns_from_query, aliases_from_query} = @query_results
-
-                    columns_from_query
+                    @query_columns
                     |> Enum.with_index()
                     |> Enum.map(fn {col, idx} ->
-                      map_get_flexible(resrow, Enum.at(aliases_from_query, idx)) ||
+                      map_get_flexible(resrow, Enum.at(@query_aliases, idx)) ||
                         map_get_flexible(resrow, col)
                     end)
 
@@ -386,17 +442,17 @@ defmodule SelectoComponents.Views.Detail.Component do
                 end %>
               <% row_data_by_uuid = Enum.zip(@column_uuids, resrow_list) |> Enum.into(%{}) %>
               <% # Also create a map by column name for subselects %>
-              <% {_results, columns_from_query, aliases_from_query} = @query_results %>
-              <% row_data_by_column = Enum.zip(columns_from_query, resrow_list) |> Map.new() %>
+              <% row_data_by_column = Enum.zip(@query_columns, resrow_list) |> Map.new() %>
               <% absolute_idx = @row_offset + display_idx %>
               <% row_action_context =
                 build_row_action_context(
                   resrow,
                   resrow_list,
                   @row_action_query_columns,
-                  columns_from_query,
-                  aliases_from_query
+                  @query_columns,
+                  @query_aliases
                 ) %>
+              <% row_selection_id = row_selection_id(row_action_context, absolute_idx) %>
               <% resolved_row_link =
                 if @row_action && @row_action.type == :external_link && @row_action_missing_fields == [] do
                   @row_action
@@ -436,6 +492,11 @@ defmodule SelectoComponents.Views.Detail.Component do
                 phx-value-row-index={if row_action_type == "modal", do: display_idx}
                 phx-target={if row_action_type == "modal", do: @myself}
               >
+                <RowSelection.row_checkbox
+                  target={@myself}
+                  row_id={row_selection_id}
+                  selected_rows={@selected_rows}
+                />
                 <td
                   class="w-12 max-w-12 min-w-12 px-2 py-1 text-center"
                   style="color: var(--sc-text-secondary); border-bottom: 1px solid var(--sc-surface-border);"
@@ -611,6 +672,58 @@ defmodule SelectoComponents.Views.Detail.Component do
     send(self(), {:update_detail_page, new_page})
 
     {:noreply, socket}
+  end
+
+  def handle_event("toggle_row_selection", %{"id" => row_id}, socket) do
+    {:noreply, RowSelection.toggle_row_selection(socket, row_id)}
+  end
+
+  def handle_event("toggle_select_all", _params, socket) do
+    visible_row_ids = Map.get(socket.assigns, :visible_row_ids, [])
+    selected_rows = Map.get(socket.assigns, :selected_rows, MapSet.new())
+    visible_selection_count = Enum.count(visible_row_ids, &MapSet.member?(selected_rows, &1))
+
+    socket =
+      if visible_row_ids != [] and visible_selection_count == length(visible_row_ids) do
+        RowSelection.clear_selection(socket)
+      else
+        RowSelection.select_all_rows(socket, visible_row_ids)
+      end
+
+    {:noreply, socket}
+  end
+
+  def handle_event("select_all", _params, socket) do
+    {:noreply,
+     RowSelection.select_all_rows(socket, Map.get(socket.assigns, :visible_row_ids, []))}
+  end
+
+  def handle_event("select_visible", _params, socket) do
+    {:noreply,
+     RowSelection.select_all_rows(socket, Map.get(socket.assigns, :visible_row_ids, []))}
+  end
+
+  def handle_event("select_none", _params, socket) do
+    {:noreply, RowSelection.clear_selection(socket)}
+  end
+
+  def handle_event("clear_selection", _params, socket) do
+    {:noreply, RowSelection.clear_selection(socket)}
+  end
+
+  def handle_event("invert_selection", _params, socket) do
+    {:noreply,
+     RowSelection.invert_selection(socket, Map.get(socket.assigns, :visible_row_ids, []))}
+  end
+
+  def handle_event("select_range", %{"from" => from_id, "to" => to_id}, socket) do
+    {:noreply,
+     RowSelection.select_range(
+       socket,
+       from_id,
+       to_id,
+       Map.get(socket.assigns, :visible_row_ids, [])
+     )}
   end
 
   def handle_event("resize_column", %{"column_id" => _column_id, "width" => _width}, socket) do
@@ -962,6 +1075,14 @@ defmodule SelectoComponents.Views.Detail.Component do
 
   defp resolve_field_value(_row, row_values, idx, _field, _column_name, _alias_name) do
     Enum.at(row_values, idx)
+  end
+
+  defp row_selection_id(%{field_values: field_values, display_record: display_record}, fallback) do
+    field_values
+    |> map_get_flexible("id")
+    |> Kernel.||(map_get_flexible(display_record, "id"))
+    |> Kernel.||(fallback)
+    |> to_string()
   end
 
   defp sanitize_row_link(nil), do: nil

--- a/lib/selecto_components/views/detail/component.ex
+++ b/lib/selecto_components/views/detail/component.ex
@@ -427,6 +427,9 @@ defmodule SelectoComponents.Views.Detail.Component do
                 data-selecto-result-row
                 data-result-row-index={display_idx}
                 data-row-action-type={row_action_type}
+                data-row-action-id={@row_action && @row_action.id}
+                data-row-action-name={@row_action && @row_action.name}
+                data-row-action-source={@row_action && @row_action.source}
                 data-row-link={resolved_row_link && resolved_row_link.url}
                 data-row-link-target={resolved_row_link && resolved_row_link.target}
                 phx-click={if row_action_type == "modal", do: "show_row_details"}

--- a/lib/selecto_components/views/detail/form.ex
+++ b/lib/selecto_components/views/detail/form.ex
@@ -224,13 +224,25 @@ defmodule SelectoComponents.Views.Detail.Form do
             <span class="font-medium" style="color: var(--sc-text-primary);">Type:</span>
             {row_action_type_label(@selected_row_action.type)}
           </div>
+          <div :if={row_action_source_label(@selected_row_action)}>
+            <span class="font-medium" style="color: var(--sc-text-primary);">Source:</span>
+            {row_action_source_label(@selected_row_action)}
+          </div>
           <div :if={@selected_row_action.description}>
             <span class="font-medium" style="color: var(--sc-text-primary);">Description:</span>
             {@selected_row_action.description}
           </div>
+          <div :if={action_form_capability(@selected_row_action)}>
+            <span class="font-medium" style="color: var(--sc-text-primary);">Capability:</span>
+            {action_form_capability(@selected_row_action)}
+          </div>
           <div>
             <span class="font-medium" style="color: var(--sc-text-primary);">Required fields:</span>
             {required_fields_label(@selected_row_action.required_fields)}
+          </div>
+          <div :if={action_form_endpoints_label(@selected_row_action)}>
+            <span class="font-medium" style="color: var(--sc-text-primary);">Endpoints:</span>
+            {action_form_endpoints_label(@selected_row_action)}
           </div>
         </div>
       </div>
@@ -356,8 +368,61 @@ defmodule SelectoComponents.Views.Detail.Form do
   defp row_action_type_label(:live_component), do: "Live component"
   defp row_action_type_label(_type), do: "Unknown"
 
+  defp row_action_source_label(%{source: :generated_action_form}),
+    do: "Generated from domain action"
+
+  defp row_action_source_label(_action), do: nil
+
+  defp action_form_capability(%{type: :live_component, payload: payload}) when is_map(payload) do
+    payload
+    |> get_in([:assigns, :action, :capability])
+    |> normalize_optional_string()
+  end
+
+  defp action_form_capability(_action), do: nil
+
+  defp action_form_endpoints_label(%{type: :live_component, payload: payload})
+       when is_map(payload) do
+    endpoints = get_in(payload, [:assigns, :action, :endpoints])
+    preview = endpoint_href(endpoints, :preview)
+    apply = endpoint_href(endpoints, :apply)
+
+    [preview && "preview: #{preview}", apply && "apply: #{apply}"]
+    |> Enum.reject(&is_nil/1)
+    |> case do
+      [] -> nil
+      parts -> Enum.join(parts, " | ")
+    end
+  end
+
+  defp action_form_endpoints_label(_action), do: nil
+
+  defp endpoint_href(endpoints, rel) when is_map(endpoints) do
+    endpoints
+    |> Map.get(rel, Map.get(endpoints, Atom.to_string(rel), %{}))
+    |> case do
+      endpoint when is_map(endpoint) -> Map.get(endpoint, :href, Map.get(endpoint, "href"))
+      _ -> nil
+    end
+    |> normalize_optional_string()
+  end
+
+  defp endpoint_href(_endpoints, _rel), do: nil
+
   defp required_fields_label([]), do: "None"
   defp required_fields_label(fields), do: Enum.join(fields, ", ")
+
+  defp normalize_optional_string(value) when is_binary(value) do
+    trimmed = String.trim(value)
+    if trimmed == "", do: nil, else: trimmed
+  end
+
+  defp normalize_optional_string(nil), do: nil
+
+  defp normalize_optional_string(value) when is_atom(value),
+    do: value |> Atom.to_string() |> normalize_optional_string()
+
+  defp normalize_optional_string(value), do: value |> to_string() |> normalize_optional_string()
 
   defp current_row_click_action(_assigns, detail_config) do
     detail_config

--- a/lib/selecto_components/views/detail/row_actions.ex
+++ b/lib/selecto_components/views/detail/row_actions.ex
@@ -33,7 +33,7 @@ defmodule SelectoComponents.Views.Detail.RowActions do
         |> Enum.find(fn action -> action.id == action_id end)
         |> case do
           nil -> nil
-          action -> Map.put(action, :source, :configured)
+          action -> Map.put_new(action, :source, :configured)
         end
     end
   end
@@ -192,6 +192,7 @@ defmodule SelectoComponents.Views.Detail.RowActions do
       required_fields: [:id],
       target: %{id: {:field, "id"}}
     )
+    |> Enum.map(fn {id, config} -> {id, Map.put(config, :source, :generated_action_form)} end)
     |> Enum.filter(fn {_id, config} ->
       action_scope =
         config
@@ -213,6 +214,7 @@ defmodule SelectoComponents.Views.Detail.RowActions do
       %{
         id: to_string(action_id),
         source_id: action_id,
+        source: normalize_action_source(map_get(action_config, :source)),
         name: normalize_optional_string(map_get(action_config, :name)) || humanize_id(action_id),
         description: normalize_optional_string(map_get(action_config, :description)),
         type: type,
@@ -283,6 +285,12 @@ defmodule SelectoComponents.Views.Detail.RowActions do
   end
 
   defp normalize_action_type(_value), do: nil
+
+  defp normalize_action_source(:generated_action_form), do: :generated_action_form
+  defp normalize_action_source("generated_action_form"), do: :generated_action_form
+  defp normalize_action_source(:configured), do: :configured
+  defp normalize_action_source("configured"), do: :configured
+  defp normalize_action_source(_source), do: nil
 
   defp normalize_modal_size(size) when size in @modal_sizes, do: size
 

--- a/lib/selecto_components/views/detail/row_actions.ex
+++ b/lib/selecto_components/views/detail/row_actions.ex
@@ -1,10 +1,14 @@
 defmodule SelectoComponents.Views.Detail.RowActions do
   @moduledoc false
 
+  alias SelectoComponents.Actions
+
   @default_modal_action_id "__default_modal__"
+  @generated_action_form_prefix "domain_action_form_"
   @modal_sizes [:sm, :md, :lg, :xl, :full, :third, :fullscreen]
 
   def default_modal_action_id, do: @default_modal_action_id
+  def generated_action_form_prefix, do: @generated_action_form_prefix
 
   def available_actions(selecto) do
     [default_modal_action() | registered_actions(selecto)]
@@ -163,13 +167,42 @@ defmodule SelectoComponents.Views.Detail.RowActions do
   def resolve_component_assigns(_assigns_template, _source), do: %{}
 
   defp registered_actions(selecto) do
-    selecto
-    |> Selecto.domain()
-    |> Map.get(:detail_actions, %{})
+    domain = Selecto.domain(selecto)
+
+    domain
+    |> registered_detail_actions()
+    |> Kernel.++(generated_action_forms(domain))
     |> Enum.map(&normalize_action/1)
     |> Enum.reject(&is_nil/1)
     |> Enum.sort_by(&String.downcase(&1.name))
   end
+
+  defp registered_detail_actions(domain) when is_map(domain) do
+    domain
+    |> Map.get(:detail_actions, %{})
+    |> Enum.to_list()
+  end
+
+  defp registered_detail_actions(_domain), do: %{}
+
+  defp generated_action_forms(domain) when is_map(domain) do
+    domain
+    |> Actions.detail_actions(
+      id_prefix: @generated_action_form_prefix,
+      required_fields: [:id],
+      target: %{id: {:field, "id"}}
+    )
+    |> Enum.filter(fn {_id, config} ->
+      action_scope =
+        config
+        |> get_in([:payload, :assigns, :action, :scope])
+        |> normalize_optional_string()
+
+      action_scope in [nil, "row"]
+    end)
+  end
+
+  defp generated_action_forms(_domain), do: []
 
   defp normalize_action({action_id, action_config}) when is_map(action_config) do
     type = normalize_action_type(map_get(action_config, :type))

--- a/test/selecto_components/action_form_host_test.exs
+++ b/test/selecto_components/action_form_host_test.exs
@@ -46,6 +46,23 @@ defmodule SelectoComponents.ActionFormHostTest do
              "apply"
   end
 
+  test "handle_submit accepts atom intents for compatibility" do
+    assert {:noreply, updated_socket} =
+             ActionFormHost.handle_submit(
+               socket(),
+               %{intent: :apply, action_id: "archive", request: %{"action" => "archive"}},
+               preview: fn _, _, _ -> flunk("preview callback should not run") end,
+               apply: fn action_id, request, _socket ->
+                 assert action_id == "archive"
+                 assert request == %{"action" => "archive"}
+                 {:ok, %{"result" => %{"mode" => "execute"}}}
+               end
+             )
+
+    assert updated_socket.assigns.modal_detail_data.component_assigns.last_result["intent"] ==
+             "apply"
+  end
+
   test "handle_submit stores formatted errors" do
     assert {:noreply, updated_socket} =
              ActionFormHost.handle_submit(

--- a/test/selecto_components/action_form_host_test.exs
+++ b/test/selecto_components/action_form_host_test.exs
@@ -46,6 +46,27 @@ defmodule SelectoComponents.ActionFormHostTest do
              "apply"
   end
 
+  test "handle_submit allows after_apply to close the modal before result assignment" do
+    assert {:noreply, updated_socket} =
+             ActionFormHost.handle_submit(
+               socket(),
+               %{intent: "apply", action_id: "archive", request: %{"action" => "archive"}},
+               preview: fn _, _, _ -> flunk("preview callback should not run") end,
+               apply: fn _action_id, _request, _socket ->
+                 {:ok, %{"result" => %{"mode" => "execute"}}}
+               end,
+               after_apply: fn socket, _result ->
+                 Phoenix.Component.assign(socket,
+                   show_detail_modal: false,
+                   modal_detail_data: nil
+                 )
+               end
+             )
+
+    assert updated_socket.assigns.show_detail_modal == false
+    assert updated_socket.assigns.modal_detail_data == nil
+  end
+
   test "handle_submit accepts atom intents for compatibility" do
     assert {:noreply, updated_socket} =
              ActionFormHost.handle_submit(

--- a/test/selecto_components/action_form_host_test.exs
+++ b/test/selecto_components/action_form_host_test.exs
@@ -1,0 +1,76 @@
+defmodule SelectoComponents.ActionFormHostTest do
+  use ExUnit.Case, async: true
+
+  alias SelectoComponents.ActionFormHost
+
+  test "handle_submit delegates preview and stores component result" do
+    socket = socket()
+
+    assert {:noreply, updated_socket} =
+             ActionFormHost.handle_submit(
+               socket,
+               %{intent: "preview", action_id: "archive", request: %{"action" => "archive"}},
+               preview: fn action_id, request, received_socket ->
+                 assert action_id == "archive"
+                 assert request == %{"action" => "archive"}
+                 assert received_socket == socket
+                 {:ok, %{"action" => action_id, "changes" => %{"state" => "archived"}}}
+               end,
+               apply: fn _, _, _ -> flunk("apply callback should not run") end
+             )
+
+    component_assigns = updated_socket.assigns.modal_detail_data.component_assigns
+    assert component_assigns.submitting == nil
+    assert component_assigns.last_error == nil
+    assert component_assigns.last_result["intent"] == "preview"
+    assert component_assigns.last_result["payload"]["changes"] == %{"state" => "archived"}
+  end
+
+  test "handle_submit delegates apply, runs after_apply, and stores component result" do
+    assert {:noreply, updated_socket} =
+             ActionFormHost.handle_submit(
+               socket(),
+               %{intent: "apply", action_id: "archive", request: %{"action" => "archive"}},
+               preview: fn _, _, _ -> flunk("preview callback should not run") end,
+               apply: fn _action_id, _request, _socket ->
+                 {:ok, %{"result" => %{"mode" => "execute"}}}
+               end,
+               after_apply: fn socket, _result ->
+                 Phoenix.Component.assign(socket, applied_view: "detail")
+               end
+             )
+
+    assert updated_socket.assigns.applied_view == "detail"
+
+    assert updated_socket.assigns.modal_detail_data.component_assigns.last_result["intent"] ==
+             "apply"
+  end
+
+  test "handle_submit stores formatted errors" do
+    assert {:noreply, updated_socket} =
+             ActionFormHost.handle_submit(
+               socket(),
+               %{intent: "preview", action_id: "archive", request: %{}},
+               preview: fn _action_id, _request, _socket ->
+                 {:error, {:validation_error, "Required", %{}}}
+               end,
+               apply: fn _, _, _ -> :unused end,
+               format_error: fn {:validation_error, message, _details} ->
+                 "Formatted: #{message}"
+               end
+             )
+
+    component_assigns = updated_socket.assigns.modal_detail_data.component_assigns
+    assert component_assigns.last_result == nil
+    assert component_assigns.last_error == "Formatted: Required"
+  end
+
+  defp socket do
+    %Phoenix.LiveView.Socket{
+      assigns: %{
+        __changed__: %{},
+        modal_detail_data: %{component_assigns: %{submitting: "preview"}}
+      }
+    }
+  end
+end

--- a/test/selecto_components/actions_test.exs
+++ b/test/selecto_components/actions_test.exs
@@ -90,6 +90,37 @@ defmodule SelectoComponents.ActionsTest do
     assert decisions == %{"approve_order" => %{"status" => "disabled"}}
   end
 
+  test "extracts decisions from action result payloads" do
+    decisions =
+      %{}
+      |> Actions.put_result_decision(:approve_order, %{
+        "preview" => %{
+          "capability_decision" => %{
+            "status" => "enabled",
+            "reason" => "Ready"
+          }
+        }
+      })
+
+    assert decisions == %{"approve_order" => %{"status" => "enabled", "reason" => "Ready"}}
+  end
+
+  test "converts validation errors into disabled decisions" do
+    decisions =
+      Actions.put_result_decision(
+        %{},
+        :approve_order,
+        {:error,
+         {:validation_error, "Action precondition failed for state.",
+          %{"code" => "action_precondition_failed", "field" => "state"}}}
+      )
+
+    assert decisions["approve_order"]["status"] == "disabled"
+    assert decisions["approve_order"]["reason"] == "Action precondition failed for state."
+    assert decisions["approve_order"]["code"] == "action_precondition_failed"
+    assert decisions["approve_order"]["metadata"]["field"] == "state"
+  end
+
   test "marks delete-like or destructive actions for guarded UI treatment" do
     contract =
       write_contract(%{

--- a/test/selecto_components/actions_test.exs
+++ b/test/selecto_components/actions_test.exs
@@ -30,6 +30,19 @@ defmodule SelectoComponents.ActionsTest do
     assert action.confirmation_message == "Approve this order?"
     assert action.reason == "Allowed by policy"
     assert action.links["preview"] == "/orders/actions/approve_order/preview"
+
+    assert action.endpoints["preview"] == %{
+             "href" => "/orders/actions/approve_order/preview",
+             "method" => "POST",
+             "rel" => "preview"
+           }
+
+    assert action.endpoints["apply"] == %{
+             "href" => "/orders/actions/approve_order/apply",
+             "method" => "POST",
+             "rel" => "apply"
+           }
+
     assert action.preview_link == "/orders/actions/approve_order/preview"
     assert action.apply_link == "/orders/actions/approve_order/apply"
 
@@ -161,6 +174,40 @@ defmodule SelectoComponents.ActionsTest do
              "action" => "approve_order",
              "target" => %{"id" => ""},
              "confirmed" => true
+           }
+  end
+
+  test "normalizes rich link maps into endpoint metadata" do
+    contract =
+      write_contract(%{
+        "escalate_order" => %{
+          "id" => "escalate_order",
+          "label" => "Escalate order",
+          "scope" => "row",
+          "capability" => "orders.escalate",
+          "execution" => %{"operation" => "update"},
+          "links" => %{
+            "preview" => %{"href" => "/orders/actions/escalate/preview", "method" => "post"},
+            "apply" => %{"path" => "/orders/actions/escalate/apply", "method" => "patch"}
+          }
+        }
+      })
+
+    action = contract |> Actions.available() |> Enum.find(&(&1.id == "escalate_order"))
+
+    assert action.preview_link == "/orders/actions/escalate/preview"
+    assert action.apply_link == "/orders/actions/escalate/apply"
+
+    assert action.endpoints["preview"] == %{
+             "href" => "/orders/actions/escalate/preview",
+             "method" => "POST",
+             "rel" => "preview"
+           }
+
+    assert action.endpoints["apply"] == %{
+             "href" => "/orders/actions/escalate/apply",
+             "method" => "PATCH",
+             "rel" => "apply"
            }
   end
 

--- a/test/selecto_components/actions_test.exs
+++ b/test/selecto_components/actions_test.exs
@@ -121,6 +121,31 @@ defmodule SelectoComponents.ActionsTest do
     assert decisions["approve_order"]["metadata"]["field"] == "state"
   end
 
+  test "summarizes and groups visible action items" do
+    actions =
+      write_contract(%{
+        "bulk_archive" => %{
+          "id" => "bulk_archive",
+          "label" => "Archive selected",
+          "scope" => "bulk",
+          "capability" => "orders.archive",
+          "execution" => %{"operation" => "update"}
+        }
+      })
+      |> Actions.available(
+        decisions: %{
+          "approve_order" => :enabled,
+          "bulk_archive" => %{status: :disabled, reason: "No selected rows"}
+        }
+      )
+
+    assert Actions.status_counts(actions) == %{"enabled" => 1, "disabled" => 1}
+    assert actions |> Actions.by_scope() |> Map.keys() |> Enum.sort() == ["bulk", "row"]
+
+    assert actions |> Actions.by_scope() |> Map.fetch!("bulk") |> hd() |> Map.fetch!(:id) ==
+             "bulk_archive"
+  end
+
   test "marks delete-like or destructive actions for guarded UI treatment" do
     contract =
       write_contract(%{

--- a/test/selecto_components/actions_test.exs
+++ b/test/selecto_components/actions_test.exs
@@ -28,6 +28,21 @@ defmodule SelectoComponents.ActionsTest do
     assert action.requires_confirmation? == true
     assert action.confirmation == %{"message" => "Approve this order?", "required" => true}
     assert action.confirmation_message == "Approve this order?"
+
+    assert action.inputs == [
+             %{"id" => "note", "required" => true, "type" => "string"},
+             %{
+               "default" => false,
+               "id" => "notify_customer",
+               "required" => false,
+               "type" => "boolean"
+             }
+           ]
+
+    assert action.input_template == %{"note" => "", "notify_customer" => false}
+    assert action.required_inputs == ["note"]
+    assert [%{"id" => "with_manager_review"} = variant] = action.variants
+    assert variant["inputs"] == [%{"id" => "manager_id", "required" => true, "type" => "integer"}]
     assert action.reason == "Allowed by policy"
     assert action.links["preview"] == "/orders/actions/approve_order/preview"
 
@@ -167,13 +182,21 @@ defmodule SelectoComponents.ActionsTest do
     assert Actions.request_template(action, target: %{"id" => "42"}, dry_run: true) == %{
              "action" => "approve_order",
              "target" => %{"id" => "42"},
+             "inputs" => %{"note" => "", "notify_customer" => false},
              "dry_run" => true
            }
 
     assert Actions.request_template(action, confirmed: true) == %{
              "action" => "approve_order",
              "target" => %{"id" => ""},
+             "inputs" => %{"note" => "", "notify_customer" => false},
              "confirmed" => true
+           }
+
+    assert Actions.request_template(action, inputs: %{"note" => "Ship it"}) == %{
+             "action" => "approve_order",
+             "target" => %{"id" => ""},
+             "inputs" => %{"note" => "Ship it"}
            }
   end
 
@@ -242,6 +265,23 @@ defmodule SelectoComponents.ActionsTest do
             "capability" => "orders.approve",
             "icon" => "check",
             "confirmation" => %{"required" => true, "message" => "Approve this order?"},
+            "inputs" => [
+              %{"id" => "note", "type" => "string", "required" => true},
+              %{
+                "id" => "notify_customer",
+                "type" => "boolean",
+                "required" => false,
+                "default" => false
+              }
+            ],
+            "variants" => [
+              %{
+                "id" => "with_manager_review",
+                "inputs" => [
+                  %{"id" => "manager_id", "type" => "integer", "required" => true}
+                ]
+              }
+            ],
             "execution" => %{"operation" => "update"},
             "links" => %{
               "preview" => "/orders/actions/approve_order/preview",

--- a/test/selecto_components/actions_test.exs
+++ b/test/selecto_components/actions_test.exs
@@ -200,6 +200,61 @@ defmodule SelectoComponents.ActionsTest do
            }
   end
 
+  test "normalizes a domain action for action form modals" do
+    action =
+      Actions.form_action(
+        %{
+          id: :approve_order,
+          label: "Approve order",
+          scope: :row,
+          capability: "orders.approve",
+          inputs: %{note: %{type: :textarea, required: true}},
+          confirmation: %{required: true, message: "Approve this order?"},
+          execution: %{operation: :update}
+        },
+        endpoint_base: "/orders/actions"
+      )
+
+    assert action.id == "approve_order"
+    assert action.operation == "update"
+    assert action.inputs == [%{"id" => "note", "required" => true, "type" => "textarea"}]
+
+    assert action.endpoints["preview"] == %{
+             "href" => "/orders/actions/approve_order/preview",
+             "method" => "POST",
+             "rel" => "preview"
+           }
+
+    assert action.endpoints["apply"]["href"] == "/orders/actions/approve_order/apply"
+  end
+
+  test "builds detail action configs for action form modals" do
+    detail_action =
+      Actions.detail_action(
+        %{
+          id: :approve_order,
+          label: "Approve order",
+          scope: :row,
+          capability: "orders.approve",
+          execution: %{operation: :update}
+        },
+        endpoint_base: "/orders/actions",
+        required_fields: [:id, :state],
+        target: %{id: {:field, "id"}},
+        title: ~S(Approve order #{{id}})
+      )
+
+    assert detail_action.type == :live_component
+    assert detail_action.required_fields == [:id, :state]
+    assert detail_action.payload.module == SelectoComponents.Modal.ActionFormModal
+    assert detail_action.payload.title == ~S(Approve order #{{id}})
+    assert detail_action.payload.assigns.target == %{id: {:field, "id"}}
+    assert detail_action.payload.assigns.action.id == "approve_order"
+
+    assert detail_action.payload.assigns.action.endpoints["preview"]["href"] ==
+             "/orders/actions/approve_order/preview"
+  end
+
   test "normalizes rich link maps into endpoint metadata" do
     contract =
       write_contract(%{

--- a/test/selecto_components/actions_test.exs
+++ b/test/selecto_components/actions_test.exs
@@ -255,6 +255,35 @@ defmodule SelectoComponents.ActionsTest do
              "/orders/actions/approve_order/preview"
   end
 
+  test "builds bulk action form configs from bulk-scoped domain actions" do
+    actions =
+      write_contract(%{
+        "bulk_archive" => %{
+          "id" => "bulk_archive",
+          "label" => "Archive selected",
+          "scope" => "bulk",
+          "capability" => "orders.archive",
+          "execution" => %{"operation" => "update"},
+          "links" => %{
+            "preview" => "/orders/actions/bulk_archive/preview",
+            "apply" => "/orders/actions/bulk_archive/apply"
+          }
+        }
+      })
+      |> Actions.bulk_actions()
+
+    assert Map.keys(actions) == ["bulk_action_form_bulk_archive"]
+
+    bulk_action = actions["bulk_action_form_bulk_archive"]
+
+    assert bulk_action.type == :live_component
+    assert bulk_action.required_fields == []
+    assert bulk_action.payload.module == SelectoComponents.Modal.ActionFormModal
+    assert bulk_action.payload.assigns.target == %{ids: {:selection, "ids"}}
+    assert bulk_action.payload.assigns.action.id == "bulk_archive"
+    assert bulk_action.payload.assigns.action.scope == "bulk"
+  end
+
   test "normalizes rich link maps into endpoint metadata" do
     contract =
       write_contract(%{

--- a/test/selecto_components/actions_test.exs
+++ b/test/selecto_components/actions_test.exs
@@ -1,0 +1,96 @@
+defmodule SelectoComponents.ActionsTest do
+  use ExUnit.Case, async: true
+
+  alias SelectoComponents.Actions
+
+  test "builds enabled action items from a write contract document" do
+    assert [action] =
+             Actions.available(write_contract(),
+               decisions: %{
+                 "approve_order" => %{
+                   status: :enabled,
+                   reason: "Allowed by policy"
+                 }
+               }
+             )
+
+    assert action.id == "approve_order"
+    assert action.label == "Approve order"
+    assert action.scope == "row"
+    assert action.operation == "update"
+    assert action.capability == "orders.approve"
+    assert action.status == "enabled"
+    assert action.disabled? == false
+    assert action.hidden? == false
+    assert action.reason == "Allowed by policy"
+    assert action.links["preview"] == "/orders/actions/approve_order/preview"
+  end
+
+  test "keeps disabled actions visible with reason metadata" do
+    assert [action] =
+             Actions.available(write_contract(),
+               decisions: %{
+                 "orders.approve" => %{
+                   "status" => "disabled",
+                   "reason" => "Approval window is closed"
+                 }
+               }
+             )
+
+    assert action.id == "approve_order"
+    assert action.status == "disabled"
+    assert action.disabled? == true
+    assert action.hidden? == false
+    assert action.reason == "Approval window is closed"
+  end
+
+  test "filters hidden actions and can scope visible actions" do
+    contract =
+      write_contract(%{
+        "bulk_archive" => %{
+          "id" => "bulk_archive",
+          "label" => "Archive selected",
+          "scope" => "bulk",
+          "capability" => "orders.archive",
+          "execution" => %{"operation" => "update"}
+        }
+      })
+
+    actions =
+      Actions.available(contract,
+        scope: :bulk,
+        decisions: %{
+          "approve_order" => %{status: :hidden, reason: "No row access"},
+          "bulk_archive" => :enabled
+        }
+      )
+
+    assert Enum.map(actions, & &1.id) == ["bulk_archive"]
+  end
+
+  test "merges preview decisions by action id" do
+    decisions = Actions.put_decision(%{}, :approve_order, %{status: :disabled})
+
+    assert decisions == %{"approve_order" => %{"status" => "disabled"}}
+  end
+
+  defp write_contract(extra_actions \\ %{}) do
+    %{
+      "projection" => "updato_write_contract",
+      "actions" =>
+        [
+          %{
+            "id" => "approve_order",
+            "label" => "Approve order",
+            "scope" => "row",
+            "capability" => "orders.approve",
+            "execution" => %{"operation" => "update"},
+            "links" => %{
+              "preview" => "/orders/actions/approve_order/preview",
+              "apply" => "/orders/actions/approve_order/apply"
+            }
+          }
+        ] ++ Map.values(extra_actions)
+    }
+  end
+end

--- a/test/selecto_components/actions_test.exs
+++ b/test/selecto_components/actions_test.exs
@@ -279,6 +279,7 @@ defmodule SelectoComponents.ActionsTest do
     assert bulk_action.type == :live_component
     assert bulk_action.required_fields == []
     assert bulk_action.payload.module == SelectoComponents.Modal.ActionFormModal
+    assert bulk_action.payload.title == "Archive selected"
     assert bulk_action.payload.assigns.target == %{ids: {:selection, "ids"}}
     assert bulk_action.payload.assigns.action.id == "bulk_archive"
     assert bulk_action.payload.assigns.action.scope == "bulk"

--- a/test/selecto_components/actions_test.exs
+++ b/test/selecto_components/actions_test.exs
@@ -16,14 +16,30 @@ defmodule SelectoComponents.ActionsTest do
 
     assert action.id == "approve_order"
     assert action.label == "Approve order"
+    assert action.description == "Approve the selected order."
     assert action.scope == "row"
     assert action.operation == "update"
     assert action.capability == "orders.approve"
+    assert action.icon == "check"
     assert action.status == "enabled"
     assert action.disabled? == false
     assert action.hidden? == false
+    assert action.destructive? == false
+    assert action.requires_confirmation? == true
     assert action.reason == "Allowed by policy"
     assert action.links["preview"] == "/orders/actions/approve_order/preview"
+    assert action.preview_link == "/orders/actions/approve_order/preview"
+    assert action.apply_link == "/orders/actions/approve_order/apply"
+
+    assert action.attrs == %{
+             "data-action-capability" => "orders.approve",
+             "data-action-confirmation" => true,
+             "data-action-destructive" => false,
+             "data-action-id" => "approve_order",
+             "data-action-operation" => "update",
+             "data-action-scope" => "row",
+             "data-action-status" => "enabled"
+           }
   end
 
   test "keeps disabled actions visible with reason metadata" do
@@ -74,6 +90,24 @@ defmodule SelectoComponents.ActionsTest do
     assert decisions == %{"approve_order" => %{"status" => "disabled"}}
   end
 
+  test "marks delete-like or destructive actions for guarded UI treatment" do
+    contract =
+      write_contract(%{
+        "delete_order" => %{
+          "id" => "delete_order",
+          "label" => "Delete order",
+          "scope" => "row",
+          "capability" => "orders.delete",
+          "execution" => %{"operation" => "delete"},
+          "confirmation" => %{"required" => true, "destructive" => true}
+        }
+      })
+
+    assert action = Enum.find(Actions.available(contract), &(&1.id == "delete_order"))
+    assert action.destructive? == true
+    assert action.requires_confirmation? == true
+  end
+
   defp write_contract(extra_actions \\ %{}) do
     %{
       "projection" => "updato_write_contract",
@@ -82,8 +116,11 @@ defmodule SelectoComponents.ActionsTest do
           %{
             "id" => "approve_order",
             "label" => "Approve order",
+            "description" => "Approve the selected order.",
             "scope" => "row",
             "capability" => "orders.approve",
+            "icon" => "check",
+            "confirmation" => %{"required" => true},
             "execution" => %{"operation" => "update"},
             "links" => %{
               "preview" => "/orders/actions/approve_order/preview",

--- a/test/selecto_components/actions_test.exs
+++ b/test/selecto_components/actions_test.exs
@@ -26,6 +26,8 @@ defmodule SelectoComponents.ActionsTest do
     assert action.hidden? == false
     assert action.destructive? == false
     assert action.requires_confirmation? == true
+    assert action.confirmation == %{"message" => "Approve this order?", "required" => true}
+    assert action.confirmation_message == "Approve this order?"
     assert action.reason == "Allowed by policy"
     assert action.links["preview"] == "/orders/actions/approve_order/preview"
     assert action.preview_link == "/orders/actions/approve_order/preview"
@@ -176,7 +178,7 @@ defmodule SelectoComponents.ActionsTest do
             "scope" => "row",
             "capability" => "orders.approve",
             "icon" => "check",
-            "confirmation" => %{"required" => true},
+            "confirmation" => %{"required" => true, "message" => "Approve this order?"},
             "execution" => %{"operation" => "update"},
             "links" => %{
               "preview" => "/orders/actions/approve_order/preview",

--- a/test/selecto_components/actions_test.exs
+++ b/test/selecto_components/actions_test.exs
@@ -148,6 +148,22 @@ defmodule SelectoComponents.ActionsTest do
              "bulk_archive"
   end
 
+  test "builds action request templates" do
+    [action] = Actions.available(write_contract())
+
+    assert Actions.request_template(action, target: %{"id" => "42"}, dry_run: true) == %{
+             "action" => "approve_order",
+             "target" => %{"id" => "42"},
+             "dry_run" => true
+           }
+
+    assert Actions.request_template(action, confirmed: true) == %{
+             "action" => "approve_order",
+             "target" => %{"id" => ""},
+             "confirmed" => true
+           }
+  end
+
   test "marks delete-like or destructive actions for guarded UI treatment" do
     contract =
       write_contract(%{

--- a/test/selecto_components/enhanced_table/bulk_actions_test.exs
+++ b/test/selecto_components/enhanced_table/bulk_actions_test.exs
@@ -72,6 +72,92 @@ defmodule SelectoComponents.EnhancedTable.BulkActionsTest do
     assert detail_data.navigation_enabled == false
   end
 
+  test "runs legacy handler bulk actions without parent process messages" do
+    test_pid = self()
+
+    {:ok, socket} =
+      BulkActions.mount(%Phoenix.LiveView.Socket{
+        assigns: %{__changed__: %{}}
+      })
+
+    {:ok, socket} =
+      BulkActions.update(
+        %{
+          id: "bulk-actions",
+          actions: [
+            %{
+              id: "legacy_archive",
+              label: "Archive",
+              batch_size: 1,
+              handler: fn ids ->
+                send(test_pid, {:handled_batch, ids})
+                {:ok, ids}
+              end
+            }
+          ],
+          selected_rows: MapSet.new(["42", "43"]),
+          selection_count: 2
+        },
+        socket
+      )
+
+    assert {:noreply, updated_socket} =
+             BulkActions.handle_event(
+               "execute_action",
+               %{"action" => "legacy_archive"},
+               socket
+             )
+
+    assert_receive {:handled_batch, ["42"]}
+    assert_receive {:handled_batch, ["43"]}
+    refute_receive {:process_batch, _, _, _}
+    refute_receive {:bulk_action_process_batch, _, _}
+
+    assert updated_socket.assigns.processing == false
+    assert updated_socket.assigns.processed_count == 2
+    assert updated_socket.assigns.errors == []
+    assert updated_socket.assigns.selected_rows == MapSet.new()
+    assert updated_socket.assigns.selection_count == 0
+  end
+
+  test "reports legacy bulk actions without handlers instead of sending orphan batches" do
+    {:ok, socket} =
+      BulkActions.mount(%Phoenix.LiveView.Socket{
+        assigns: %{__changed__: %{}}
+      })
+
+    {:ok, socket} =
+      BulkActions.update(
+        %{
+          id: "bulk-actions",
+          actions: [%{id: "legacy_archive", label: "Archive"}],
+          selected_rows: MapSet.new(["42", "43"]),
+          selection_count: 2
+        },
+        socket
+      )
+
+    assert {:noreply, updated_socket} =
+             BulkActions.handle_event(
+               "execute_action",
+               %{"action" => "legacy_archive"},
+               socket
+             )
+
+    refute_receive {:process_batch, _, _, _}
+    refute_receive {:bulk_action_process_batch, _, _}
+
+    assert updated_socket.assigns.processing == false
+    assert updated_socket.assigns.processed_count == 0
+
+    assert updated_socket.assigns.errors == [
+             "No handler configured for bulk action legacy_archive."
+           ]
+
+    assert updated_socket.assigns.selected_rows == MapSet.new(["42", "43"])
+    assert updated_socket.assigns.selection_count == 2
+  end
+
   defp bulk_contract do
     %{
       actions: %{

--- a/test/selecto_components/enhanced_table/bulk_actions_test.exs
+++ b/test/selecto_components/enhanced_table/bulk_actions_test.exs
@@ -18,6 +18,21 @@ defmodule SelectoComponents.EnhancedTable.BulkActionsTest do
     assert html =~ ~s(data-bulk-action-source="generated_bulk_action_form")
     assert html =~ ~s(data-bulk-action-scope="bulk")
     assert html =~ "Archive selected"
+    assert html =~ ~s(id="bulk-actions-menu")
+  end
+
+  test "renders a visible empty state when no bulk actions are available" do
+    html =
+      render_component(BulkActions, %{
+        id: "bulk-actions-empty",
+        actions: [],
+        selected_rows: MapSet.new(["42"]),
+        selection_count: 1
+      })
+
+    assert html =~ ~s(id="bulk-actions-empty-menu")
+    assert html =~ ~s(data-bulk-actions-empty)
+    assert html =~ "No bulk actions available"
   end
 
   test "opens a generated bulk action form with selected ids as the target" do

--- a/test/selecto_components/enhanced_table/bulk_actions_test.exs
+++ b/test/selecto_components/enhanced_table/bulk_actions_test.exs
@@ -73,111 +73,22 @@ defmodule SelectoComponents.EnhancedTable.BulkActionsTest do
     assert detail_data.navigation_enabled == false
   end
 
-  test "marks deprecated explicit handler bulk actions and avoids parent process messages" do
-    test_pid = self()
-
+  test "ignores explicit actions now that bulk actions come from domain contracts" do
     html =
       render_component(BulkActions, %{
         id: "bulk-actions",
         actions: [
           %{
             id: "legacy_archive",
-            label: "Archive",
-            batch_size: 1,
-            handler: fn ids ->
-              send(test_pid, {:handled_batch, ids})
-              {:ok, ids}
-            end
+            label: "Archive"
           }
         ],
         selected_rows: MapSet.new(["42", "43"]),
         selection_count: 2
       })
 
-    assert html =~ ~s(data-bulk-action-id="legacy_archive")
-    assert html =~ ~s(data-bulk-action-source="deprecated_explicit_bulk_action")
-
-    {:ok, socket} =
-      BulkActions.mount(%Phoenix.LiveView.Socket{
-        assigns: %{__changed__: %{}}
-      })
-
-    {:ok, socket} =
-      BulkActions.update(
-        %{
-          id: "bulk-actions",
-          actions: [
-            %{
-              id: "legacy_archive",
-              label: "Archive",
-              batch_size: 1,
-              handler: fn ids ->
-                send(test_pid, {:handled_batch, ids})
-                {:ok, ids}
-              end
-            }
-          ],
-          selected_rows: MapSet.new(["42", "43"]),
-          selection_count: 2
-        },
-        socket
-      )
-
-    assert {:noreply, updated_socket} =
-             BulkActions.handle_event(
-               "execute_action",
-               %{"action" => "legacy_archive"},
-               socket
-             )
-
-    assert_receive {:handled_batch, ["42"]}
-    assert_receive {:handled_batch, ["43"]}
-    refute_receive {:process_batch, _, _, _}
-    refute_receive {:bulk_action_process_batch, _, _}
-
-    assert updated_socket.assigns.processing == false
-    assert updated_socket.assigns.processed_count == 2
-    assert updated_socket.assigns.errors == []
-    assert updated_socket.assigns.selected_rows == MapSet.new()
-    assert updated_socket.assigns.selection_count == 0
-  end
-
-  test "reports legacy bulk actions without handlers instead of sending orphan batches" do
-    {:ok, socket} =
-      BulkActions.mount(%Phoenix.LiveView.Socket{
-        assigns: %{__changed__: %{}}
-      })
-
-    {:ok, socket} =
-      BulkActions.update(
-        %{
-          id: "bulk-actions",
-          actions: [%{id: "legacy_archive", label: "Archive"}],
-          selected_rows: MapSet.new(["42", "43"]),
-          selection_count: 2
-        },
-        socket
-      )
-
-    assert {:noreply, updated_socket} =
-             BulkActions.handle_event(
-               "execute_action",
-               %{"action" => "legacy_archive"},
-               socket
-             )
-
-    refute_receive {:process_batch, _, _, _}
-    refute_receive {:bulk_action_process_batch, _, _}
-
-    assert updated_socket.assigns.processing == false
-    assert updated_socket.assigns.processed_count == 0
-
-    assert updated_socket.assigns.errors == [
-             "No handler configured for bulk action legacy_archive."
-           ]
-
-    assert updated_socket.assigns.selected_rows == MapSet.new(["42", "43"])
-    assert updated_socket.assigns.selection_count == 2
+    assert html =~ ~s(data-bulk-actions-empty)
+    refute html =~ ~s(data-bulk-action-id="legacy_archive")
   end
 
   defp bulk_contract do

--- a/test/selecto_components/enhanced_table/bulk_actions_test.exs
+++ b/test/selecto_components/enhanced_table/bulk_actions_test.exs
@@ -25,7 +25,6 @@ defmodule SelectoComponents.EnhancedTable.BulkActionsTest do
     html =
       render_component(BulkActions, %{
         id: "bulk-actions-empty",
-        actions: [],
         selected_rows: MapSet.new(["42"]),
         selection_count: 1
       })
@@ -33,6 +32,8 @@ defmodule SelectoComponents.EnhancedTable.BulkActionsTest do
     assert html =~ ~s(id="bulk-actions-empty-menu")
     assert html =~ ~s(data-bulk-actions-empty)
     assert html =~ "No bulk actions available"
+    refute html =~ ~s(data-bulk-action-id="archive")
+    refute html =~ ~s(data-bulk-action-id="delete")
   end
 
   test "opens a generated bulk action form with selected ids as the target" do
@@ -72,8 +73,29 @@ defmodule SelectoComponents.EnhancedTable.BulkActionsTest do
     assert detail_data.navigation_enabled == false
   end
 
-  test "runs legacy handler bulk actions without parent process messages" do
+  test "marks deprecated explicit handler bulk actions and avoids parent process messages" do
     test_pid = self()
+
+    html =
+      render_component(BulkActions, %{
+        id: "bulk-actions",
+        actions: [
+          %{
+            id: "legacy_archive",
+            label: "Archive",
+            batch_size: 1,
+            handler: fn ids ->
+              send(test_pid, {:handled_batch, ids})
+              {:ok, ids}
+            end
+          }
+        ],
+        selected_rows: MapSet.new(["42", "43"]),
+        selection_count: 2
+      })
+
+    assert html =~ ~s(data-bulk-action-id="legacy_archive")
+    assert html =~ ~s(data-bulk-action-source="deprecated_explicit_bulk_action")
 
     {:ok, socket} =
       BulkActions.mount(%Phoenix.LiveView.Socket{

--- a/test/selecto_components/enhanced_table/bulk_actions_test.exs
+++ b/test/selecto_components/enhanced_table/bulk_actions_test.exs
@@ -1,0 +1,78 @@
+defmodule SelectoComponents.EnhancedTable.BulkActionsTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest, only: [render_component: 2]
+
+  alias SelectoComponents.EnhancedTable.BulkActions
+
+  test "renders generated bulk action forms from a domain contract" do
+    html =
+      render_component(BulkActions, %{
+        id: "bulk-actions",
+        action_contract: bulk_contract(),
+        selected_rows: MapSet.new(["42"]),
+        selection_count: 1
+      })
+
+    assert html =~ ~s(data-bulk-action-id="domain_bulk_action_form_bulk_archive")
+    assert html =~ ~s(data-bulk-action-source="generated_bulk_action_form")
+    assert html =~ ~s(data-bulk-action-scope="bulk")
+    assert html =~ "Archive selected"
+  end
+
+  test "opens a generated bulk action form with selected ids as the target" do
+    {:ok, socket} =
+      BulkActions.mount(%Phoenix.LiveView.Socket{
+        assigns: %{__changed__: %{}}
+      })
+
+    {:ok, socket} =
+      BulkActions.update(
+        %{
+          id: "bulk-actions",
+          action_contract: bulk_contract(),
+          selected_rows: MapSet.new(["42", "43"]),
+          selection_count: 2
+        },
+        socket
+      )
+
+    assert {:noreply, updated_socket} =
+             BulkActions.handle_event(
+               "execute_action",
+               %{"action" => "domain_bulk_action_form_bulk_archive"},
+               socket
+             )
+
+    assert_receive {:show_detail_modal, detail_data}
+
+    assert updated_socket.assigns.bulk_action.id == "domain_bulk_action_form_bulk_archive"
+    assert detail_data.action_source == :generated_bulk_action_form
+    assert detail_data.action_type == :live_component
+    assert detail_data.component_module == SelectoComponents.Modal.ActionFormModal
+    assert detail_data.component_assigns.target.ids == ["42", "43"]
+    assert detail_data.component_assigns.action.id == "bulk_archive"
+    assert detail_data.component_assigns.action.scope == "bulk"
+    assert detail_data.record == %{"ids" => ["42", "43"], "count" => 2}
+    assert detail_data.navigation_enabled == false
+  end
+
+  defp bulk_contract do
+    %{
+      actions: %{
+        bulk_archive: %{
+          id: :bulk_archive,
+          label: "Archive selected",
+          description: "Archive every selected row.",
+          scope: :bulk,
+          capability: "orders.archive",
+          execution: %{operation: :update},
+          links: %{
+            preview: "/orders/actions/bulk_archive/preview",
+            apply: "/orders/actions/bulk_archive/apply"
+          }
+        }
+      }
+    }
+  end
+end

--- a/test/selecto_components/enhanced_table/row_selection_test.exs
+++ b/test/selecto_components/enhanced_table/row_selection_test.exs
@@ -1,0 +1,33 @@
+defmodule SelectoComponents.EnhancedTable.RowSelectionTest do
+  use ExUnit.Case, async: true
+
+  alias SelectoComponents.EnhancedTable.RowSelection
+
+  defp socket(assigns \\ []) do
+    Phoenix.Component.assign(
+      %Phoenix.LiveView.Socket{},
+      Keyword.merge(
+        [
+          selected_rows: MapSet.new(),
+          selection_count: 0,
+          selection_mode: :multiple,
+          select_all: false
+        ],
+        assigns
+      )
+    )
+  end
+
+  test "does not notify host liveviews by default" do
+    RowSelection.toggle_row_selection(socket(), "1541")
+
+    refute_receive {:selection_changed, _selected_rows}
+  end
+
+  test "can notify host liveviews when explicitly enabled" do
+    RowSelection.toggle_row_selection(socket(notify_selection_change: true), "1541")
+
+    assert_receive {:selection_changed, selected_rows}
+    assert selected_rows == MapSet.new(["1541"])
+  end
+end

--- a/test/selecto_components/form/modal_router_test.exs
+++ b/test/selecto_components/form/modal_router_test.exs
@@ -50,4 +50,35 @@ defmodule SelectoComponents.Form.ModalRouterTest do
     assert html =~ "Open in new tab"
     assert html =~ "https://example.com/detail/1"
   end
+
+  test "routes live component action forms through the modal router" do
+    html =
+      render_component(&ModalRouter.router/1, %{
+        visible: true,
+        modal_detail_data: %{
+          action_type: :live_component,
+          record: %{"id" => 42, "title" => "Launch"},
+          records: [%{"id" => 42, "title" => "Launch"}],
+          current_index: 0,
+          total_records: 1,
+          component_module: SelectoComponents.Modal.ActionFormModal,
+          component_assigns: %{
+            action: %{
+              "id" => "archive",
+              "label" => "Archive",
+              "description" => "Move to archive",
+              "operation" => "update",
+              "scope" => "row",
+              "confirmation" => %{"required" => true, "message" => "Archive this row?"}
+            },
+            target: %{"id" => 42}
+          }
+        }
+      })
+
+    assert html =~ ~s(data-selecto-action-form-modal)
+    assert html =~ "Archive"
+    assert html =~ "Archive this row?"
+    assert html =~ ~s(&quot;action&quot;: &quot;archive&quot;)
+  end
 end

--- a/test/selecto_components/form/modal_router_test.exs
+++ b/test/selecto_components/form/modal_router_test.exs
@@ -79,6 +79,8 @@ defmodule SelectoComponents.Form.ModalRouterTest do
     assert html =~ ~s(data-selecto-action-form-modal)
     assert html =~ "Archive"
     assert html =~ "Archive this row?"
-    assert html =~ ~s(&quot;action&quot;: &quot;archive&quot;)
+    assert html =~ ~s(data-action-id="archive")
+    assert html =~ ~s(data-action-operation="update")
+    refute html =~ "Request template"
   end
 end

--- a/test/selecto_components/form_test.exs
+++ b/test/selecto_components/form_test.exs
@@ -543,6 +543,41 @@ defmodule SelectoComponents.FormTest do
     assert html =~ "Archive"
   end
 
+  test "renders generated bulk action form modals without the legacy modal flag" do
+    html =
+      render_component(
+        Form,
+        base_assigns(%{
+          show_detail_modal: true,
+          enable_modal_detail: false,
+          modal_detail_data: %{
+            action_source: :generated_bulk_action_form,
+            action_type: :live_component,
+            record: %{"ids" => ["42", "43"], "count" => 2},
+            records: [%{"ids" => ["42", "43"], "count" => 2}],
+            current_index: 0,
+            total_records: 2,
+            component_module: SelectoComponents.Modal.ActionFormModal,
+            component_assigns: %{
+              action: %{
+                "id" => "bulk_archive",
+                "label" => "Archive selected",
+                "description" => "Move selected rows to archive",
+                "operation" => "update",
+                "scope" => "bulk",
+                "confirmation" => %{"required" => true, "message" => "Archive selected rows?"}
+              },
+              target: %{"ids" => ["42", "43"]}
+            }
+          }
+        })
+      )
+
+    assert html =~ ~s(data-selecto-action-form-modal)
+    assert html =~ "Archive selected"
+    assert html =~ "bulk"
+  end
+
   test "string IS NULL filters keep the standard operator list instead of switching to datetime controls" do
     html =
       render_component(

--- a/test/selecto_components/form_test.exs
+++ b/test/selecto_components/form_test.exs
@@ -509,6 +509,40 @@ defmodule SelectoComponents.FormTest do
     assert partial_in_values_id == full_in_values_id
   end
 
+  test "renders generated action form modals without the legacy modal flag" do
+    html =
+      render_component(
+        Form,
+        base_assigns(%{
+          show_detail_modal: true,
+          enable_modal_detail: false,
+          modal_detail_data: %{
+            action_source: :generated_action_form,
+            action_type: :live_component,
+            record: %{"id" => 42, "title" => "Launch"},
+            records: [%{"id" => 42, "title" => "Launch"}],
+            current_index: 0,
+            total_records: 1,
+            component_module: SelectoComponents.Modal.ActionFormModal,
+            component_assigns: %{
+              action: %{
+                "id" => "archive",
+                "label" => "Archive",
+                "description" => "Move to archive",
+                "operation" => "update",
+                "scope" => "row",
+                "confirmation" => %{"required" => true, "message" => "Archive this row?"}
+              },
+              target: %{"id" => 42}
+            }
+          }
+        })
+      )
+
+    assert html =~ ~s(data-selecto-action-form-modal)
+    assert html =~ "Archive"
+  end
+
   test "string IS NULL filters keep the standard operator list instead of switching to datetime controls" do
     html =
       render_component(

--- a/test/selecto_components/modal/action_form_modal_test.exs
+++ b/test/selecto_components/modal/action_form_modal_test.exs
@@ -21,7 +21,7 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert_receive {:selecto_action_form_submit, payload}
     assert payload.intent == "preview"
     assert payload.action_id == "archive"
-    assert payload.endpoint == %{"href" => "/actions/archive/preview", "method" => "POST"}
+    assert Map.keys(payload) |> Enum.sort() == [:action_id, :intent, :request]
 
     assert payload.request == %{
              "action" => "archive",
@@ -42,7 +42,7 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
 
     assert_receive {:selecto_action_form_submit, payload}
     assert payload.intent == "apply"
-    assert payload.endpoint == %{"href" => "/actions/archive/apply", "method" => "POST"}
+    assert Map.keys(payload) |> Enum.sort() == [:action_id, :intent, :request]
     assert payload.request["confirmed"] == true
     assert payload.request["dry_run"] == false
   end
@@ -141,9 +141,9 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert preview_html =~ ~s(data-selecto-action-form-result-summary)
     assert preview_html =~ ~s(data-selecto-action-form-result-summary-item="action")
     assert preview_html =~ ~s(data-selecto-action-form-result-summary-item="changes")
-    assert preview_html =~ ~s(data-selecto-action-form-result-details)
     assert preview_html =~ ~s(data-selecto-action-form-reset)
     assert preview_html =~ ~s({&quot;state&quot;:&quot;archived&quot;})
+    refute preview_html =~ ~s(data-selecto-action-form-result-details)
 
     apply_html =
       render_component(ActionFormModal, %{
@@ -163,8 +163,36 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert apply_html =~ ~s(data-selecto-action-form-result-summary-item="mode")
     assert apply_html =~ ~s(execute)
     assert apply_html =~ ~s(data-selecto-action-form-result-summary-item="record")
-    assert apply_html =~ ~s(data-selecto-action-form-result-details)
-    assert apply_html =~ ~s(Response details)
+    refute apply_html =~ ~s(data-selecto-action-form-result-details)
+    refute apply_html =~ ~s(Response details)
+  end
+
+  test "render keeps raw request and response JSON behind an explicit debug flag" do
+    default_html =
+      render_component(ActionFormModal, %{
+        id: "action-form",
+        action: action(),
+        target: %{id: 42},
+        record: %{"id" => 42},
+        last_result: %{"intent" => "preview", "payload" => %{"action" => "archive"}}
+      })
+
+    refute default_html =~ "Request template"
+    refute default_html =~ "Response details"
+
+    debug_html =
+      render_component(ActionFormModal, %{
+        id: "action-form",
+        action: action(),
+        target: %{id: 42},
+        record: %{"id" => 42},
+        show_debug_json?: true,
+        last_result: %{"intent" => "preview", "payload" => %{"action" => "archive"}}
+      })
+
+    assert debug_html =~ "Request template"
+    assert debug_html =~ "Response details"
+    assert debug_html =~ ~s(data-selecto-action-form-result-details)
   end
 
   test "render summarizes bulk apply results without expanding every record in the summary" do
@@ -193,7 +221,7 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert html =~ ~s(data-selecto-action-form-result-summary-item="records")
     assert html =~ "3 records"
     refute html =~ ~s(data-selecto-action-form-result-summary-item="record")
-    assert html =~ ~s(data-selecto-action-form-result-details)
+    refute html =~ ~s(data-selecto-action-form-result-details)
   end
 
   test "render disables unavailable action forms with the host reason" do

--- a/test/selecto_components/modal/action_form_modal_test.exs
+++ b/test/selecto_components/modal/action_form_modal_test.exs
@@ -176,6 +176,61 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
            }
   end
 
+  test "submit_action_form blocks missing required inputs before notifying host" do
+    action =
+      Map.put(action(), "inputs", [
+        %{
+          "id" => "archive_reason",
+          "type" => "textarea",
+          "label" => "Archive reason",
+          "required" => true
+        },
+        %{"id" => "notify_customer", "type" => "boolean", "required" => true}
+      ])
+
+    assert {:noreply, updated_socket} =
+             ActionFormModal.handle_event(
+               "submit_action_form",
+               %{
+                 "intent" => "preview",
+                 "inputs" => %{"archive_reason" => "   ", "notify_customer" => "false"}
+               },
+               socket(action, %{id: 42})
+             )
+
+    assert updated_socket.assigns.submitting == nil
+    assert updated_socket.assigns.last_error == "Required inputs missing: Archive reason."
+    refute_received {:selecto_action_form_submit, _payload}
+  end
+
+  test "render marks non-boolean required inputs for browser validation" do
+    html =
+      render_component(ActionFormModal, %{
+        id: "action-form",
+        action:
+          Map.put(action(), "inputs", [
+            %{
+              "id" => "archive_reason",
+              "type" => "textarea",
+              "label" => "Archive reason",
+              "required" => true
+            },
+            %{
+              "id" => "notify_customer",
+              "type" => "boolean",
+              "label" => "Notify",
+              "required" => true
+            }
+          ]),
+        target: %{id: 42},
+        record: %{"id" => 42}
+      })
+
+    assert html =~ ~r/<textarea[^>]+name="inputs\[archive_reason\]"[^>]+required/
+    assert html =~ ~r/<input[^>]+name="inputs\[notify_customer\]"[^>]+type="checkbox"/
+    refute html =~ ~r/<input[^>]+name="inputs\[notify_customer\]"[^>]+\srequired(?:\s|>)/
+  end
+
   defp socket(action, target) do
     %Phoenix.LiveView.Socket{
       assigns: %{

--- a/test/selecto_components/modal/action_form_modal_test.exs
+++ b/test/selecto_components/modal/action_form_modal_test.exs
@@ -84,6 +84,98 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert html =~ ~r/value="apply"[\s\S]*disabled/
   end
 
+  test "render supports textarea and select action inputs" do
+    html =
+      render_component(ActionFormModal, %{
+        id: "action-form",
+        action:
+          Map.put(action(), "inputs", [
+            %{"id" => "archive_reason", "type" => "textarea", "label" => "Archive reason"},
+            %{
+              "id" => "archive_disposition",
+              "type" => "string",
+              "label" => "Disposition",
+              "default" => "obsolete",
+              "options" => [
+                %{"value" => "obsolete", "label" => "Obsolete"},
+                %{"value" => "duplicate", "label" => "Duplicate"}
+              ]
+            }
+          ]),
+        target: %{id: 42},
+        record: %{"id" => 42}
+      })
+
+    assert html =~ ~s(<textarea)
+    assert html =~ ~s(name="inputs[archive_reason]")
+    assert html =~ ~s(<select name="inputs[archive_disposition]")
+    assert html =~ ~s(<option value="obsolete" selected)
+    assert html =~ "Duplicate"
+  end
+
+  test "render supports normalized contract inputs with raw option metadata" do
+    html =
+      render_component(ActionFormModal, %{
+        id: "action-form",
+        action:
+          Map.put(action(), "inputs", [
+            %{
+              "id" => "archive_disposition",
+              "type" => "string",
+              "label" => "Disposition",
+              "default" => "completed",
+              "raw" => %{
+                "options" => [
+                  %{"value" => "completed", "label" => "Completed"},
+                  %{"value" => "obsolete", "label" => "Obsolete"}
+                ]
+              }
+            },
+            %{
+              "id" => "archive_reason",
+              "type" => "textarea",
+              "label" => "Archive reason",
+              "raw" => %{"rows" => 3}
+            }
+          ]),
+        target: %{id: 42},
+        record: %{"id" => 42}
+      })
+
+    assert html =~ ~s(<select name="inputs[archive_disposition]")
+    assert html =~ ~s(<option value="completed" selected)
+    assert html =~ ~s(<textarea name="inputs[archive_reason]" rows="3")
+  end
+
+  test "submit_action_form normalizes declared boolean inputs while preserving extras" do
+    action =
+      Map.put(action(), "inputs", [
+        %{"id" => "note", "type" => "string"},
+        %{"id" => "notify_customer", "type" => "boolean"}
+      ])
+
+    assert {:noreply, updated_socket} =
+             ActionFormModal.handle_event(
+               "submit_action_form",
+               %{"intent" => "preview", "inputs" => %{"note" => "Ready", "unexpected" => "kept"}},
+               socket(action, %{id: 42})
+             )
+
+    assert updated_socket.assigns.form_inputs == %{
+             "note" => "Ready",
+             "notify_customer" => false,
+             "unexpected" => "kept"
+           }
+
+    assert_receive {:selecto_action_form_submit, payload}
+
+    assert payload.request["inputs"] == %{
+             "note" => "Ready",
+             "notify_customer" => false,
+             "unexpected" => "kept"
+           }
+  end
+
   defp socket(action, target) do
     %Phoenix.LiveView.Socket{
       assigns: %{

--- a/test/selecto_components/modal/action_form_modal_test.exs
+++ b/test/selecto_components/modal/action_form_modal_test.exs
@@ -90,6 +90,34 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert html =~ ~s(data-selecto-action-form-submit="apply")
   end
 
+  test "render carries numeric input constraints from action metadata" do
+    html =
+      render_component(ActionFormModal, %{
+        id: "action-form",
+        action: %{
+          action()
+          | "inputs" => [
+              %{
+                "id" => "estimate_hours",
+                "type" => "integer",
+                "required" => true,
+                "default" => 4,
+                "min" => 0,
+                "max" => 40,
+                "step" => 1
+              }
+            ]
+        },
+        target: %{id: 42},
+        record: %{"id" => 42}
+      })
+
+    assert html =~ ~r/data-selecto-action-form-input="estimate_hours"[\s\S]*type="number"/
+    assert html =~ ~r/data-selecto-action-form-input="estimate_hours"[\s\S]*min="0"/
+    assert html =~ ~r/data-selecto-action-form-input="estimate_hours"[\s\S]*max="40"/
+    assert html =~ ~r/data-selecto-action-form-input="estimate_hours"[\s\S]*step="1"/
+  end
+
   test "reset_action_form clears non-applied result state" do
     socket =
       socket(action(), %{id: 42})

--- a/test/selecto_components/modal/action_form_modal_test.exs
+++ b/test/selecto_components/modal/action_form_modal_test.exs
@@ -59,8 +59,35 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
       })
 
     assert html =~ ~s(data-selecto-action-form-applied)
+    assert html =~ ~s(data-action-status="applied")
+
+    assert html =~
+             ~r/data-selecto-action-form-input="note"[\s\S]*name="inputs\[note\]"[\s\S]*disabled/
+
+    assert html =~ ~r/name="confirmed"[\s\S]*disabled/
     assert html =~ ~r/value="preview"[\s\S]*disabled/
     assert html =~ ~r/value="apply"[\s\S]*disabled/
+  end
+
+  test "render exposes stable action metadata and submit hooks" do
+    html =
+      render_component(ActionFormModal, %{
+        id: "action-form",
+        action: Map.put(action(), "capability", "work_items.archive"),
+        target: %{id: 42},
+        record: %{"id" => 42},
+        confirmed: true
+      })
+
+    assert html =~ ~s(data-selecto-action-form-modal)
+    assert html =~ ~s(data-action-id="archive")
+    assert html =~ ~s(data-action-capability="work_items.archive")
+    assert html =~ ~s(data-action-operation="update")
+    assert html =~ ~s(data-action-scope="row")
+    assert html =~ ~s(data-action-status="enabled")
+    assert html =~ ~s(data-selecto-action-form-input="note")
+    assert html =~ ~s(data-selecto-action-form-submit="preview")
+    assert html =~ ~s(data-selecto-action-form-submit="apply")
   end
 
   test "render summarizes preview and apply results" do
@@ -117,7 +144,13 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
       })
 
     assert html =~ ~s(data-selecto-action-form-disabled)
+    assert html =~ ~s(data-action-status="disabled")
     assert html =~ "Action precondition failed for state."
+
+    assert html =~
+             ~r/data-selecto-action-form-input="note"[\s\S]*name="inputs\[note\]"[\s\S]*disabled/
+
+    assert html =~ ~r/name="confirmed"[\s\S]*disabled/
     assert html =~ ~r/value="preview"[\s\S]*disabled/
     assert html =~ ~r/value="apply"[\s\S]*disabled/
   end
@@ -146,7 +179,7 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
 
     assert html =~ ~s(<textarea)
     assert html =~ ~s(name="inputs[archive_reason]")
-    assert html =~ ~s(<select name="inputs[archive_disposition]")
+    assert html =~ ~r/<select[^>]+name="inputs\[archive_disposition\]"/
     assert html =~ ~s(<option value="obsolete" selected)
     assert html =~ "Duplicate"
   end
@@ -180,9 +213,9 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
         record: %{"id" => 42}
       })
 
-    assert html =~ ~s(<select name="inputs[archive_disposition]")
+    assert html =~ ~r/<select[^>]+name="inputs\[archive_disposition\]"/
     assert html =~ ~s(<option value="completed" selected)
-    assert html =~ ~s(<textarea name="inputs[archive_reason]" rows="3")
+    assert html =~ ~r/<textarea[^>]+name="inputs\[archive_reason\]"[^>]+rows="3"/
   end
 
   test "submit_action_form normalizes declared boolean inputs while preserving extras" do

--- a/test/selecto_components/modal/action_form_modal_test.exs
+++ b/test/selecto_components/modal/action_form_modal_test.exs
@@ -90,6 +90,41 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert html =~ ~s(data-selecto-action-form-submit="apply")
   end
 
+  test "reset_action_form clears non-applied result state" do
+    socket =
+      socket(action(), %{id: 42})
+      |> Phoenix.Component.assign(
+        submitting: "preview",
+        last_request: %{"action" => "archive"},
+        last_result: %{"intent" => "preview", "payload" => %{"action" => "archive"}},
+        last_error: "Preview failed"
+      )
+
+    assert {:noreply, updated_socket} =
+             ActionFormModal.handle_event("reset_action_form", %{}, socket)
+
+    assert updated_socket.assigns.submitting == nil
+    assert updated_socket.assigns.last_request == nil
+    assert updated_socket.assigns.last_result == nil
+    assert updated_socket.assigns.last_error == nil
+  end
+
+  test "reset_action_form preserves applied result lock" do
+    socket =
+      socket(action(), %{id: 42})
+      |> Phoenix.Component.assign(
+        last_result: %{"intent" => "apply", "payload" => %{"action" => "archive"}}
+      )
+
+    assert {:noreply, updated_socket} =
+             ActionFormModal.handle_event("reset_action_form", %{}, socket)
+
+    assert updated_socket.assigns.last_result == %{
+             "intent" => "apply",
+             "payload" => %{"action" => "archive"}
+           }
+  end
+
   test "render summarizes preview and apply results" do
     preview_html =
       render_component(ActionFormModal, %{
@@ -106,6 +141,7 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert preview_html =~ ~s(data-selecto-action-form-result-summary)
     assert preview_html =~ ~s(data-selecto-action-form-result-summary-item="action")
     assert preview_html =~ ~s(data-selecto-action-form-result-summary-item="changes")
+    assert preview_html =~ ~s(data-selecto-action-form-reset)
     assert preview_html =~ ~s({&quot;state&quot;:&quot;archived&quot;})
 
     apply_html =

--- a/test/selecto_components/modal/action_form_modal_test.exs
+++ b/test/selecto_components/modal/action_form_modal_test.exs
@@ -63,6 +63,44 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert html =~ ~r/value="apply"[\s\S]*disabled/
   end
 
+  test "render summarizes preview and apply results" do
+    preview_html =
+      render_component(ActionFormModal, %{
+        id: "action-form",
+        action: action(),
+        target: %{id: 42},
+        record: %{"id" => 42},
+        last_result: %{
+          "intent" => "preview",
+          "payload" => %{"action" => "archive", "changes" => %{"state" => "archived"}}
+        }
+      })
+
+    assert preview_html =~ ~s(data-selecto-action-form-result-summary)
+    assert preview_html =~ ~s(data-selecto-action-form-result-summary-item="action")
+    assert preview_html =~ ~s(data-selecto-action-form-result-summary-item="changes")
+    assert preview_html =~ ~s({&quot;state&quot;:&quot;archived&quot;})
+
+    apply_html =
+      render_component(ActionFormModal, %{
+        id: "action-form",
+        action: action(),
+        target: %{id: 42},
+        record: %{"id" => 42},
+        last_result: %{
+          "intent" => "apply",
+          "payload" => %{
+            "preview" => %{"action" => "archive", "changes" => %{"state" => "archived"}},
+            "result" => %{"mode" => "execute", "record" => %{"id" => 42, "state" => "archived"}}
+          }
+        }
+      })
+
+    assert apply_html =~ ~s(data-selecto-action-form-result-summary-item="mode")
+    assert apply_html =~ ~s(execute)
+    assert apply_html =~ ~s(data-selecto-action-form-result-summary-item="record")
+  end
+
   test "render disables unavailable action forms with the host reason" do
     html =
       render_component(ActionFormModal, %{

--- a/test/selecto_components/modal/action_form_modal_test.exs
+++ b/test/selecto_components/modal/action_form_modal_test.exs
@@ -141,6 +141,7 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert preview_html =~ ~s(data-selecto-action-form-result-summary)
     assert preview_html =~ ~s(data-selecto-action-form-result-summary-item="action")
     assert preview_html =~ ~s(data-selecto-action-form-result-summary-item="changes")
+    assert preview_html =~ ~s(data-selecto-action-form-result-details)
     assert preview_html =~ ~s(data-selecto-action-form-reset)
     assert preview_html =~ ~s({&quot;state&quot;:&quot;archived&quot;})
 
@@ -162,6 +163,37 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert apply_html =~ ~s(data-selecto-action-form-result-summary-item="mode")
     assert apply_html =~ ~s(execute)
     assert apply_html =~ ~s(data-selecto-action-form-result-summary-item="record")
+    assert apply_html =~ ~s(data-selecto-action-form-result-details)
+    assert apply_html =~ ~s(Response details)
+  end
+
+  test "render summarizes bulk apply results without expanding every record in the summary" do
+    html =
+      render_component(ActionFormModal, %{
+        id: "action-form",
+        action: action(),
+        target: %{"ids" => ["1541", "1542", "1543"]},
+        record: %{},
+        last_result: %{
+          "intent" => "apply",
+          "payload" => %{
+            "preview" => %{"action" => "bulk_archive"},
+            "result" => %{
+              "mode" => "execute",
+              "record" => [
+                %{"id" => 1541, "state" => "archived"},
+                %{"id" => 1542, "state" => "archived"},
+                %{"id" => 1543, "state" => "archived"}
+              ]
+            }
+          }
+        }
+      })
+
+    assert html =~ ~s(data-selecto-action-form-result-summary-item="records")
+    assert html =~ "3 records"
+    refute html =~ ~s(data-selecto-action-form-result-summary-item="record")
+    assert html =~ ~s(data-selecto-action-form-result-details)
   end
 
   test "render disables unavailable action forms with the host reason" do

--- a/test/selecto_components/modal/action_form_modal_test.exs
+++ b/test/selecto_components/modal/action_form_modal_test.exs
@@ -1,0 +1,74 @@
+defmodule SelectoComponents.Modal.ActionFormModalTest do
+  use ExUnit.Case, async: true
+
+  alias SelectoComponents.Modal.ActionFormModal
+
+  test "submit_action_form emits a preview request payload" do
+    socket = socket(action(), %{id: 42})
+
+    assert {:noreply, updated_socket} =
+             ActionFormModal.handle_event(
+               "submit_action_form",
+               %{"intent" => "preview", "inputs" => %{"note" => "Ready"}},
+               socket
+             )
+
+    assert updated_socket.assigns.submitting == "preview"
+    assert updated_socket.assigns.last_request["dry_run"] == true
+
+    assert_receive {:selecto_action_form_submit, payload}
+    assert payload.intent == "preview"
+    assert payload.action_id == "archive"
+    assert payload.endpoint == %{"href" => "/actions/archive/preview", "method" => "POST"}
+
+    assert payload.request == %{
+             "action" => "archive",
+             "target" => %{"id" => 42},
+             "inputs" => %{"note" => "Ready"},
+             "dry_run" => true,
+             "confirmed" => false
+           }
+  end
+
+  test "submit_action_form emits a confirmed apply request payload" do
+    assert {:noreply, _socket} =
+             ActionFormModal.handle_event(
+               "submit_action_form",
+               %{"intent" => "apply", "confirmed" => "true"},
+               socket(action(), %{id: 42})
+             )
+
+    assert_receive {:selecto_action_form_submit, payload}
+    assert payload.intent == "apply"
+    assert payload.endpoint == %{"href" => "/actions/archive/apply", "method" => "POST"}
+    assert payload.request["confirmed"] == true
+    assert payload.request["dry_run"] == false
+  end
+
+  defp socket(action, target) do
+    %Phoenix.LiveView.Socket{
+      assigns: %{
+        __changed__: %{},
+        action: action,
+        target: target,
+        record: %{"id" => 42},
+        inputs: Map.fetch!(action, "inputs")
+      }
+    }
+  end
+
+  defp action do
+    %{
+      "id" => "archive",
+      "label" => "Archive",
+      "scope" => "row",
+      "operation" => "update",
+      "inputs" => [%{"id" => "note", "type" => "string"}],
+      "confirmation" => %{"required" => true, "message" => "Archive?"},
+      "endpoints" => %{
+        "preview" => %{"href" => "/actions/archive/preview", "method" => "POST"},
+        "apply" => %{"href" => "/actions/archive/apply", "method" => "POST"}
+      }
+    }
+  end
+end

--- a/test/selecto_components/modal/action_form_modal_test.exs
+++ b/test/selecto_components/modal/action_form_modal_test.exs
@@ -1,6 +1,8 @@
 defmodule SelectoComponents.Modal.ActionFormModalTest do
   use ExUnit.Case, async: true
 
+  import Phoenix.LiveViewTest, only: [render_component: 2]
+
   alias SelectoComponents.Modal.ActionFormModal
 
   test "submit_action_form emits a preview request payload" do
@@ -43,6 +45,22 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert payload.endpoint == %{"href" => "/actions/archive/apply", "method" => "POST"}
     assert payload.request["confirmed"] == true
     assert payload.request["dry_run"] == false
+  end
+
+  test "render disables further submissions after apply succeeds" do
+    html =
+      render_component(ActionFormModal, %{
+        id: "action-form",
+        action: action(),
+        target: %{id: 42},
+        record: %{"id" => 42},
+        confirmed: true,
+        last_result: %{"intent" => "apply", "payload" => %{"action" => "archive"}}
+      })
+
+    assert html =~ ~s(data-selecto-action-form-applied)
+    assert html =~ ~r/value="preview"[\s\S]*disabled/
+    assert html =~ ~r/value="apply"[\s\S]*disabled/
   end
 
   defp socket(action, target) do

--- a/test/selecto_components/modal/action_form_modal_test.exs
+++ b/test/selecto_components/modal/action_form_modal_test.exs
@@ -63,6 +63,27 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert html =~ ~r/value="apply"[\s\S]*disabled/
   end
 
+  test "render disables unavailable action forms with the host reason" do
+    html =
+      render_component(ActionFormModal, %{
+        id: "action-form",
+        action:
+          Map.merge(action(), %{
+            "status" => "disabled",
+            "disabled?" => true,
+            "reason" => "Action precondition failed for state."
+          }),
+        target: %{id: 42},
+        record: %{"id" => 42},
+        confirmed: true
+      })
+
+    assert html =~ ~s(data-selecto-action-form-disabled)
+    assert html =~ "Action precondition failed for state."
+    assert html =~ ~r/value="preview"[\s\S]*disabled/
+    assert html =~ ~r/value="apply"[\s\S]*disabled/
+  end
+
   defp socket(action, target) do
     %Phoenix.LiveView.Socket{
       assigns: %{

--- a/test/selecto_components/query_contract_test.exs
+++ b/test/selecto_components/query_contract_test.exs
@@ -87,6 +87,22 @@ defmodule SelectoComponents.QueryContractTest do
     end
   end
 
+  describe "json_safe/1" do
+    test "normalizes date and time structs before generic map traversal" do
+      assert QueryContract.json_safe(%{
+               inserted_at: ~N[2026-05-14 18:56:38],
+               published_at: ~U[2026-05-14 18:56:38Z],
+               due_on: ~D[2026-05-14],
+               starts_at: ~T[18:56:38]
+             }) == %{
+               "inserted_at" => "2026-05-14T18:56:38",
+               "published_at" => "2026-05-14T18:56:38Z",
+               "due_on" => "2026-05-14",
+               "starts_at" => "18:56:38"
+             }
+    end
+  end
+
   describe "json_document/1" do
     test "returns a JSON-ready query contract document" do
       assert {:ok, document, diagnostics} =

--- a/test/selecto_components/views/detail/component_test.exs
+++ b/test/selecto_components/views/detail/component_test.exs
@@ -543,6 +543,71 @@ defmodule SelectoComponents.Views.Detail.ComponentTest do
     assert detail_data.component_assigns.workspace_name == "Austin Workspace 2-1"
   end
 
+  test "show_row_details can open an action form live component" do
+    domain = %{
+      name: "DetailActionFormTest",
+      source: %{
+        source_table: "work_items",
+        primary_key: :id,
+        fields: [:id, :title],
+        redact_fields: [],
+        columns: %{id: %{type: :integer}, title: %{type: :string}},
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{},
+      detail_actions: %{
+        archive_form: %{
+          name: "Archive",
+          type: :live_component,
+          required_fields: [:id, :title],
+          payload: %{
+            title: ~S(Archive #{{id}}),
+            module: SelectoComponents.Modal.ActionFormModal,
+            assigns: %{
+              target: %{id: {:field, "id"}},
+              action: %{
+                id: "archive",
+                label: "Archive",
+                description: "Move a completed work item into the archived state.",
+                operation: "update",
+                scope: "row",
+                confirmation: %{required: true, message: "Archive this work item?"}
+              }
+            }
+          }
+        }
+      }
+    }
+
+    socket = %Phoenix.LiveView.Socket{
+      assigns: %{
+        selecto:
+          Selecto.configure(domain, nil)
+          |> Map.put(:set, %{
+            columns: [
+              %{"field" => "id", "alias" => "id", "uuid" => "id-col"},
+              %{"field" => "title", "alias" => "title", "uuid" => "title-col"}
+            ]
+          }),
+        enable_modal_detail: false,
+        view_meta: %{row_click_action: "archive_form"},
+        processed_results: {[[42, "Ship archive forms"]], ["id", "title"]},
+        query_results: {[[42, "Ship archive forms"]], ["id", "title"], ["id", "title"]}
+      }
+    }
+
+    assert {:noreply, _socket} =
+             Component.handle_event("show_row_details", %{"row-index" => "0"}, socket)
+
+    assert_receive {:show_detail_modal, detail_data}
+    assert detail_data.action_type == :live_component
+    assert detail_data.component_module == SelectoComponents.Modal.ActionFormModal
+    assert detail_data.component_assigns.target.id == 42
+    assert detail_data.component_assigns.action.id == "archive"
+    assert detail_data.title == "Archive #42"
+  end
+
   test "renders external link row action data attributes" do
     domain = %{
       name: "DetailExternalLinkTest",

--- a/test/selecto_components/views/detail/component_test.exs
+++ b/test/selecto_components/views/detail/component_test.exs
@@ -71,6 +71,109 @@ defmodule SelectoComponents.Views.Detail.ComponentTest do
     assert html =~ ~s(tabindex="-1")
   end
 
+  test "renders bulk selection checkboxes and toolbar for detail rows" do
+    domain = %{
+      name: "DetailBulkSelectionTest",
+      source: %{
+        source_table: "work_items",
+        primary_key: :id,
+        fields: [:id, :title],
+        redact_fields: [],
+        columns: %{id: %{type: :integer}, title: %{type: :string}},
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{},
+      actions: %{
+        archive_selected: %{
+          id: :archive_selected,
+          label: "Archive selected",
+          scope: :bulk,
+          capability: "work_items.archive",
+          execution: %{operation: :update},
+          links: %{
+            preview: "/work-items/actions/archive_selected/preview",
+            apply: "/work-items/actions/archive_selected/apply"
+          },
+          inputs: [%{id: :reason, type: :textarea, required: true}]
+        }
+      }
+    }
+
+    selecto =
+      Selecto.configure(domain, nil)
+      |> Map.put(:set, %{
+        columns: [
+          %{"field" => "id", "alias" => "id", "uuid" => "id-col"},
+          %{"field" => "title", "alias" => "title", "uuid" => "title-col"}
+        ]
+      })
+
+    html =
+      render_component(Component, %{
+        id: "detail-bulk-selection-test",
+        executed: true,
+        execution_error: nil,
+        selecto: selecto,
+        query_results:
+          {[[42, "Archive me"], [43, "Archive me too"]], ["id", "title"], ["id", "title"]},
+        view_meta: %{page: 0, per_page: 10, total_rows: 2, subselect_configs: []}
+      })
+
+    assert html =~ ~s(id="select-all-checkbox")
+    assert html =~ ~s(id="row-checkbox-42")
+    assert html =~ ~s(id="row-checkbox-43")
+    assert html =~ ~s(id="detail-bulk-actions-detail-bulk-selection-test")
+    assert html =~ ~s(data-bulk-action-id="domain_bulk_action_form_archive_selected")
+    refute html =~ ~s(data-bulk-action-id="archive")
+  end
+
+  test "detail selection events update selected row ids" do
+    socket =
+      Phoenix.Component.assign(
+        %Phoenix.LiveView.Socket{},
+        selected_rows: MapSet.new(),
+        selection_count: 0,
+        selection_mode: :multiple,
+        select_all: false,
+        visible_row_ids: ["42", "43"]
+      )
+
+    assert {:noreply, socket} =
+             Component.handle_event("toggle_row_selection", %{"id" => "42"}, socket)
+
+    assert socket.assigns.selection_count == 1
+    assert MapSet.member?(socket.assigns.selected_rows, "42")
+
+    assert {:noreply, socket} = Component.handle_event("toggle_select_all", %{}, socket)
+    assert socket.assigns.selection_count == 2
+    assert socket.assigns.selected_rows == MapSet.new(["42", "43"])
+
+    assert {:noreply, socket} = Component.handle_event("toggle_select_all", %{}, socket)
+    assert socket.assigns.selection_count == 0
+    assert socket.assigns.selected_rows == MapSet.new()
+  end
+
+  test "detail render prunes selected ids that are no longer visible" do
+    html =
+      render_component(
+        Component,
+        base_assigns(%{
+          selected_rows: MapSet.new(["1541", "1542", "1543"]),
+          selection_count: 3,
+          select_all: false,
+          query_results: {[[1544], [1545]], ["id"], ["id"]},
+          view_meta: %{page: 0, per_page: 10, total_rows: 2, subselect_configs: []}
+        })
+      )
+
+    assert html =~ ~s(data-selected-count="0")
+    refute html =~ "3 selected"
+    refute html =~ ~s(id="row-checkbox-1541")
+    assert html =~ ~s(id="row-checkbox-1544")
+    assert html =~ ~s(id="row-checkbox-1545")
+  end
+
   test "disables forward pagination buttons on the last page" do
     assigns =
       base_assigns(%{

--- a/test/selecto_components/views/detail/component_test.exs
+++ b/test/selecto_components/views/detail/component_test.exs
@@ -608,6 +608,68 @@ defmodule SelectoComponents.Views.Detail.ComponentTest do
     assert detail_data.title == "Archive #42"
   end
 
+  test "show_row_details can open generated domain action form live components" do
+    domain = %{
+      name: "GeneratedDetailActionFormTest",
+      source: %{
+        source_table: "work_items",
+        primary_key: :id,
+        fields: [:id, :title],
+        redact_fields: [],
+        columns: %{id: %{type: :integer}, title: %{type: :string}},
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{},
+      detail_actions: %{},
+      actions: %{
+        archive: %{
+          id: :archive,
+          label: "Archive",
+          scope: :row,
+          capability: "work_items.archive",
+          execution: %{operation: :update},
+          links: %{
+            preview: "/work-items/actions/archive/preview",
+            apply: "/work-items/actions/archive/apply"
+          },
+          inputs: [%{id: :reason, type: :textarea, required: true}]
+        }
+      }
+    }
+
+    socket = %Phoenix.LiveView.Socket{
+      assigns: %{
+        selecto:
+          Selecto.configure(domain, nil)
+          |> Map.put(:set, %{
+            columns: [
+              %{"field" => "id", "alias" => "id", "uuid" => "id-col"},
+              %{"field" => "title", "alias" => "title", "uuid" => "title-col"}
+            ]
+          }),
+        enable_modal_detail: false,
+        view_meta: %{row_click_action: "domain_action_form_archive"},
+        processed_results: {[[42, "Ship archive forms"]], ["id", "title"]},
+        query_results: {[[42, "Ship archive forms"]], ["id", "title"], ["id", "title"]}
+      }
+    }
+
+    assert {:noreply, _socket} =
+             Component.handle_event("show_row_details", %{"row-index" => "0"}, socket)
+
+    assert_receive {:show_detail_modal, detail_data}
+    assert detail_data.action_type == :live_component
+    assert detail_data.component_module == SelectoComponents.Modal.ActionFormModal
+    assert detail_data.component_assigns.target.id == 42
+    assert detail_data.component_assigns.action.id == "archive"
+
+    assert detail_data.component_assigns.action.endpoints.preview.href ==
+             "/work-items/actions/archive/preview"
+
+    assert detail_data.title == "Archive #42"
+  end
+
   test "renders external link row action data attributes" do
     domain = %{
       name: "DetailExternalLinkTest",

--- a/test/selecto_components/views/detail/component_test.exs
+++ b/test/selecto_components/views/detail/component_test.exs
@@ -660,6 +660,7 @@ defmodule SelectoComponents.Views.Detail.ComponentTest do
 
     assert_receive {:show_detail_modal, detail_data}
     assert detail_data.action_type == :live_component
+    assert detail_data.action_source == :generated_action_form
     assert detail_data.component_module == SelectoComponents.Modal.ActionFormModal
     assert detail_data.component_assigns.target.id == 42
     assert detail_data.component_assigns.action.id == "archive"

--- a/test/selecto_components/views/detail/form_test.exs
+++ b/test/selecto_components/views/detail/form_test.exs
@@ -60,6 +60,60 @@ defmodule SelectoComponents.Views.Detail.FormTest do
     assert html =~ ~s(<option value="work_item_api_json" selected>)
   end
 
+  test "renders generated row action form choices from domain actions" do
+    domain = %{
+      name: "DetailFormGeneratedActionsTest",
+      source: %{
+        source_table: "work_items",
+        primary_key: :id,
+        fields: [:id, :title],
+        redact_fields: [],
+        columns: %{
+          id: %{type: :integer, name: "ID", colid: :id},
+          title: %{type: :string, name: "Title", colid: :title}
+        },
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{},
+      detail_actions: %{},
+      actions: %{
+        archive: %{
+          id: :archive,
+          label: "Archive",
+          scope: :row,
+          capability: "work_items.archive",
+          execution: %{operation: :update},
+          links: %{
+            preview: "/work-items/actions/archive/preview",
+            apply: "/work-items/actions/archive/apply"
+          }
+        }
+      }
+    }
+
+    html =
+      render_component(Form, %{
+        id: "detail-form-generated-actions-test",
+        columns: [{:id, "ID", :integer}, {:title, "Title", :string}],
+        view: {:detail, SelectoComponents.Views.Detail, "Detail", %{}},
+        selecto: Selecto.configure(domain, nil),
+        view_config: %{
+          views: %{
+            detail: %{
+              selected: [],
+              order_by: [],
+              row_click_action: "domain_action_form_archive"
+            }
+          }
+        }
+      })
+
+    assert html =~ ~s(id="detail-row-click-action-domain_action_form_archive")
+    assert html =~ ~s(<option value="domain_action_form_archive" selected>)
+    assert html =~ "Archive"
+  end
+
   test "uses detail config as the only row click action source while editing" do
     domain = %{
       name: "DetailFormParamsTest",

--- a/test/selecto_components/views/detail/form_test.exs
+++ b/test/selecto_components/views/detail/form_test.exs
@@ -112,6 +112,10 @@ defmodule SelectoComponents.Views.Detail.FormTest do
     assert html =~ ~s(id="detail-row-click-action-domain_action_form_archive")
     assert html =~ ~s(<option value="domain_action_form_archive" selected>)
     assert html =~ "Archive"
+    assert html =~ "Generated from domain action"
+    assert html =~ "work_items.archive"
+    assert html =~ "preview: /work-items/actions/archive/preview"
+    assert html =~ "apply: /work-items/actions/archive/apply"
   end
 
   test "uses detail config as the only row click action source while editing" do


### PR DESCRIPTION
Superseded by the upstream PR: https://github.com/selecto-elixir/selecto_components/pull/69

Closing this fork-local PR so the action work lands through the upstream repo. Please squash-merge the upstream PR.